### PR TITLE
feat(diagnose): report macOS version for easier triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,36 @@ ntfsmac help
 Device identifiers are validated against `^disk[0-9]+s[0-9]+$` before any command touches
 them — see [SECURITY.md](SECURITY.md).
 
+## Troubleshooting
+
+Installed but a drive won't mount, or the app "starts but does nothing"? Run the built-in
+health check first — it's read-only and never mounts anything:
+
+```sh
+ntfsmac diagnose          # human-readable
+ntfsmac diagnose --json   # same data on one line, handy for bug reports
+```
+
+What each line means:
+
+| `diagnose` line | Meaning / fix |
+| --- | --- |
+| `macOS version: <ver>` | Must be **13.0+** on Apple Silicon. An `unsupported` note here is fatal — older macOS can't run the microVM path. |
+| `vendor binaries missing: N` (N > 0) | A vendored binary (`anylinuxfs`/`gvproxy`/`vmnet-helper`/`vmproxy`) wasn't found. Reinstall: `brew reinstall ntfsmac`, or re-run `install.sh`. |
+| `quarantined binaries: N` (N > 0) | Gatekeeper quarantined a vendored binary, so it won't launch. Reinstall (the installer strips the xattr), or clear it: `xattr -dr com.apple.quarantine <path>`. |
+| `kernel pin: mismatch` / `missing` | The pinned `modules.squashfs` kernel image doesn't match `sources.lock`. Reinstall to restore the pinned image. |
+| `vmnet bridge: down` | Expected when nothing is mounted; it should read `up` while a volume is mounted. If it stays `down` during a mount, approve the vmnet-helper permission prompt and retry. |
+| `current NFS mounts:` | Lists your mounted volume(s); `(none)` when idle. |
+| `overall: degraded` | One of the fatal checks above failed — fix that line first. |
+
+Filing a bug? Please include:
+
+- the `ntfsmac diagnose --json` output,
+- your macOS version (`sw_vers -productVersion`) and Mac model,
+- the disk identifier you used, in `diskNsN` form (e.g. `disk4s1` — a partition, not the whole `disk4`).
+
+For security issues, see [SECURITY.md](SECURITY.md) — please don't file those publicly.
+
 ## GUI
 
 Menu-bar app (no Dock icon): pick a drive, mount it, get out of the way. Menu-bar icon color

--- a/cli/commands/diagnose.sh
+++ b/cli/commands/diagnose.sh
@@ -129,24 +129,58 @@ current_mounts() {
   mount -t nfs 2>/dev/null | awk '{print $1, "on", $3}'
 }
 
+# check_macos_version — reports the macOS product version. Two reasons diagnose grew this:
+# (1) triage reports (see README "Troubleshooting" / the issue tracker) kept omitting the OS
+# version, so the first ask on every "installed but not working" report was "which macOS?";
+# (2) ntfsmac requires macOS 13.0+, so an older host is a real cause of that symptom, worth
+# flagging directly. Overridable for tests via NTFSMAC_MACOS_VERSION_OVERRIDE — note the `-`
+# (not `:-`) default: an explicitly-set empty value simulates sw_vers returning nothing
+# (reported as "unknown"), while leaving it unset runs sw_vers normally. bash-3.2 + set -u
+# safe (plain default expansion, no indirect ${!var}).
+check_macos_version() {
+  local ver
+  ver="${NTFSMAC_MACOS_VERSION_OVERRIDE-$(sw_vers -productVersion 2>/dev/null)}"
+  if [[ -n "$ver" ]]; then
+    printf '%s\n' "$ver"
+  else
+    printf 'unknown\n'
+  fi
+}
+
 main() {
   local kernel_pin bridge mounts healthy=1
+  local macos_version macos_major macos_supported=1
   MISSING_BINS=0
   QUARANTINED_BINS=0
 
+  macos_version="$(check_macos_version)"
   check_vendor_binaries
   kernel_pin="$(check_kernel_pin)"
   bridge="$(check_bridge_up)"
   mounts="$(current_mounts)"
+
+  # ntfsmac requires macOS 13.0+ on Apple Silicon. Only a real, parseable major version
+  # below 13 flips health; an unknown/undetected version is reported but left non-fatal.
+  # Portable "is it all digits" test (case glob) instead of a regex — bash-3.2 safe.
+  macos_major="${macos_version%%.*}"
+  case "$macos_major" in
+    ''|*[!0-9]*) macos_major="" ;;
+  esac
+  if [[ -n "$macos_major" && "$macos_major" -lt 13 ]]; then
+    healthy=0
+    macos_supported=0
+  fi
 
   [[ "$MISSING_BINS" -gt 0 ]] && healthy=0
   [[ "$QUARANTINED_BINS" -gt 0 ]] && healthy=0
   [[ "$kernel_pin" == "mismatch" ]] && healthy=0
 
   if [[ $json_mode -eq 1 ]]; then
-    printf '{"healthy":%s,"missing_binaries":%s,"quarantined_binaries":%s,"kernel_pin":"%s","bridge":"%s"}\n' \
-      "$([[ $healthy -eq 1 ]] && echo true || echo false)" "$MISSING_BINS" "$QUARANTINED_BINS" "$kernel_pin" "$bridge"
+    printf '{"healthy":%s,"macos_version":"%s","missing_binaries":%s,"quarantined_binaries":%s,"kernel_pin":"%s","bridge":"%s"}\n' \
+      "$([[ $healthy -eq 1 ]] && echo true || echo false)" "$macos_version" "$MISSING_BINS" "$QUARANTINED_BINS" "$kernel_pin" "$bridge"
   else
+    echo "diagnose: macOS version: $macos_version"
+    [[ "$macos_supported" -eq 0 ]] && echo "diagnose:   unsupported — ntfsmac requires macOS 13.0+"
     echo "diagnose: vendor binaries missing: $MISSING_BINS"
     echo "diagnose: quarantined binaries: $QUARANTINED_BINS"
     echo "diagnose: kernel pin: $kernel_pin"

--- a/tests/cli/diagnose.bats
+++ b/tests/cli/diagnose.bats
@@ -69,6 +69,40 @@ teardown() {
   [[ "$output" == *'"quarantined_binaries":0'* ]]
 }
 
+@test "reports a supported macOS version and stays healthy" {
+  export NTFSMAC_MACOS_VERSION_OVERRIDE="14.5"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"macOS version: 14.5"* ]]
+  [[ "$output" == *"overall: healthy"* ]]
+}
+
+@test "--json includes the macos_version field" {
+  export NTFSMAC_MACOS_VERSION_OVERRIDE="14.5"
+  run "$SCRIPT" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"macos_version":"14.5"'* ]]
+}
+
+@test "degraded: macOS older than 13.0 is unsupported" {
+  export NTFSMAC_MACOS_VERSION_OVERRIDE="12.6"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"macOS version: 12.6"* ]]
+  [[ "$output" == *"unsupported"* ]]
+  [[ "$output" == *"overall: degraded"* ]]
+}
+
+@test "an undetected macOS version is reported as unknown but not fatal" {
+  # Explicit empty override simulates sw_vers returning nothing (the `-` default in
+  # check_macos_version keeps an empty *set* value rather than re-running sw_vers).
+  export NTFSMAC_MACOS_VERSION_OVERRIDE=""
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"macOS version: unknown"* ]]
+  [[ "$output" == *"overall: healthy"* ]]
+}
+
 @test "falls back to \$PREFIX/libexec when a binary isn't on PATH (install.sh layout, not PATH by design)" {
   # Real install.sh layout: gvproxy/vmnet-helper/vmproxy live in libexec, never on PATH.
   # Without an env override or PATH entry, the old PATH-only check misreported these as


### PR DESCRIPTION
## What

`ntfsmac diagnose` reports vendor binaries, quarantine, kernel pin, vmnet bridge and NFS mounts — but never the macOS version, which is the first thing needed to triage an "installed but not working" report (e.g. #1, where the reporter's macOS version was never captured).

This PR:

- **`cli/commands/diagnose.sh`** — adds a read-only `check_macos_version()` that prints the product version in both plain and `--json` output. macOS **< 13.0** is flagged `unsupported` and flips `overall` to `degraded` (ntfsmac requires 13.0+); an undetected version is reported as `unknown` and left non-fatal. The version lookup is overridable via `NTFSMAC_MACOS_VERSION_OVERRIDE` (same testability idiom as the existing `NTFSMAC_*_BIN` overrides) and is bash-3.2 + `set -u` safe. The new `"macos_version"` JSON key is **additive** — existing keys are unchanged, so the GUI's parse contract is preserved.
- **`tests/cli/diagnose.bats`** — adds cases for supported / unsupported / unknown versions and the new `--json` field.
- **`README.md`** — adds a **Troubleshooting** section mapping each `diagnose` line to a fix and describing how to file a useful bug report.

## Constraints respected (CLAUDE.md / PLAN.md §6)

- `diagnose` stays fully read-only — `sw_vers` only; no mount/unmount/pf/route. The existing "read-only" test still passes.
- bash-3.2-safe (no `declare -A`, no `${!var}`); `set -u`-safe defaults.
- `--json` change is additive only.

## Testing

Not built/run locally (no Apple Silicon Mac on hand); relying on CI (`macos-26`): shellcheck `-S warning`, `tests/run-all.sh` (auto-discovers the new bats cases), and `swift build`/`swift test`. The version-parsing and `<13` health logic were verified in isolation.

Refs PLAN.md §6 (2-diagnose). Refs #1.
