### PR TITLE
fix(gui): reflect real launch-at-login status

### DIFF
--- a/docs/dev/SHARED_TASK_NOTES.md
+++ b/docs/dev/SHARED_TASK_NOTES.md
@@ -605,6 +605,13 @@ resolved.
       every other Phase 3 unit so far, confirmed deliberate, not a gap.
       Real `swift build`/`swift test`: clean, zero warnings beyond the two pre-existing
       `SMJobCopyDictionary`/`SMJobBless` deprecation warnings, 77/77 (4 new).
+      **Launch-at-login follow-up:** the existing writable `launchAtLogin` API and the original
+      `LaunchAtLoginService.setEnabled(_:)` requirement remain source-compatible. A separate,
+      optional status protocol now reconciles the switch with `SMAppService.mainApp.status`, shows
+      pending System Settings approval or registration failures instead of persisting a false
+      success, and refreshes when Preferences opens. The control uses the current macOS switch
+      style and is disabled only while registration is in flight; legacy injected services retain
+      the prior UserDefaults-backed behavior.
 - [x] `3-liquid-glass` — `gui/Style/Colors.swift`, `gui/Style/GlassTheme.swift`, plus color/wiring
       edits across `gui/Status/StatusIcon.swift`, `gui/Views/SecurityIndicators.swift`,
       `gui/Views/FirstRunView.swift`, `gui/App/NtfsmacApp.swift`, `gui/Preferences/

--- a/gui/Preferences/PreferencesView.swift
+++ b/gui/Preferences/PreferencesView.swift
@@ -19,8 +19,23 @@ public struct PreferencesView: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            row("Launch at login", "Start ntfsmac automatically on login") {
-                Toggle("", isOn: $settings.launchAtLogin).labelsHidden()
+            row("Launch at login", launchAtLoginSubtitle) {
+                HStack(spacing: 8) {
+                    if settings.isUpdatingLaunchAtLogin {
+                        ProgressView().controlSize(.small)
+                    }
+                    Toggle(
+                        "Launch at login",
+                        isOn: Binding(
+                            get: { settings.launchAtLogin },
+                            set: { settings.setLaunchAtLogin($0) }
+                        )
+                    )
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .disabled(settings.isUpdatingLaunchAtLogin)
+                    .accessibilityLabel("Launch at login")
+                }
             }
 
             Divider()
@@ -51,6 +66,7 @@ public struct PreferencesView: View {
         .padding(16)
         .frame(width: 360)
         .windowGlassBackground()
+        .onAppear { settings.refreshLaunchAtLoginStatus() }
         .confirmationDialog(
             "Uninstall ntfsmac completely?",
             isPresented: $isConfirmingUninstall
@@ -73,6 +89,10 @@ public struct PreferencesView: View {
         case .failed(let message):
             return "Failed: \(message)"
         }
+    }
+
+    private var launchAtLoginSubtitle: String {
+        settings.launchAtLoginMessage ?? "Start ntfsmac automatically on login"
     }
 
     @ViewBuilder

--- a/gui/Preferences/Settings.swift
+++ b/gui/Preferences/Settings.swift
@@ -1,6 +1,13 @@
 import Foundation
 import ServiceManagement
 
+public enum LaunchAtLoginRegistrationStatus: Equatable, Sendable {
+    case disabled
+    case enabled
+    case requiresApproval
+    case unavailable
+}
+
 /// Seam over `SMAppService.mainApp` (macOS 13+, matches L7's floor — not the deprecated
 /// `SMLoginItemSetEnabled`) so a toggled-on "Launch at login" preference actually registers the
 /// login item rather than just persisting a bool nothing acts on, which would be a silently
@@ -9,8 +16,29 @@ public protocol LaunchAtLoginService: Sendable {
     func setEnabled(_ enabled: Bool) throws
 }
 
-public struct RealLaunchAtLoginService: LaunchAtLoginService {
+/// Optional status capability kept separate from `LaunchAtLoginService` so existing service
+/// conformers remain source compatible.
+public protocol LaunchAtLoginStatusProviding: LaunchAtLoginService {
+    var status: LaunchAtLoginRegistrationStatus { get }
+}
+
+public struct RealLaunchAtLoginService: LaunchAtLoginStatusProviding {
     public init() {}
+
+    public var status: LaunchAtLoginRegistrationStatus {
+        switch SMAppService.mainApp.status {
+        case .notRegistered:
+            return .disabled
+        case .enabled:
+            return .enabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notFound:
+            return .unavailable
+        @unknown default:
+            return .unavailable
+        }
+    }
 
     public func setEnabled(_ enabled: Bool) throws {
         if enabled {
@@ -21,32 +49,153 @@ public struct RealLaunchAtLoginService: LaunchAtLoginService {
     }
 }
 
-/// GUI-PLAN.md "Preferences window" table, exactly these five controls — this unit's Don't
-/// clause: no controls beyond this table. Persisted via `UserDefaults` (constructor-injected so
-/// tests use an isolated suite, never the real `.standard` domain).
+private enum LaunchAtLoginUpdateResult: Sendable {
+    case success(LaunchAtLoginRegistrationStatus)
+    case failure(message: String, status: LaunchAtLoginRegistrationStatus)
+}
+
+/// Preference state backed by the real Service Management registration. `UserDefaults` mirrors
+/// confirmed state and remains the fallback for injected legacy services that cannot report
+/// status.
 @MainActor
 public final class Settings: ObservableObject {
     @Published public var launchAtLogin: Bool {
         didSet {
-            defaults.set(launchAtLogin, forKey: Keys.launchAtLogin)
-            // ponytail: SMAppService.register/unregister is a blocking IPC call — same class of
-            // call HelperInstaller.runOffCooperativePool avoids running on the main actor.
-            let loginService = self.loginService
-            let enabled = launchAtLogin
-            Task.detached(priority: .userInitiated) {
-                try? loginService.setEnabled(enabled)
-            }
+            guard !isApplyingLaunchAtLoginStatus else { return }
+            beginLaunchAtLoginUpdate(launchAtLogin)
         }
     }
+    @Published public private(set) var isUpdatingLaunchAtLogin = false
+    @Published public private(set) var launchAtLoginMessage: String?
 
     private let defaults: UserDefaults
     private let loginService: any LaunchAtLoginService
+    private var confirmedLaunchAtLogin: Bool
+    private var isApplyingLaunchAtLoginStatus = false
 
     public init(defaults: UserDefaults = .standard, loginService: any LaunchAtLoginService = RealLaunchAtLoginService()) {
         self.defaults = defaults
         self.loginService = loginService
 
-        launchAtLogin = defaults.object(forKey: Keys.launchAtLogin) as? Bool ?? Defaults.launchAtLogin
+        let persisted = defaults.object(forKey: Keys.launchAtLogin) as? Bool ?? Defaults.launchAtLogin
+        let registrationStatus = Self.registrationStatus(for: loginService, fallbackEnabled: persisted)
+        let initialValue = registrationStatus == .enabled
+
+        launchAtLogin = initialValue
+        confirmedLaunchAtLogin = initialValue
+        launchAtLoginMessage = Self.message(for: registrationStatus)
+        defaults.set(initialValue, forKey: Keys.launchAtLogin)
+    }
+
+    /// Updates the real Service Management registration and then reads it back. The explicit
+    /// method powers the UI while the original writable `launchAtLogin` property remains supported
+    /// for existing callers.
+    public func setLaunchAtLogin(_ enabled: Bool) {
+        guard !isUpdatingLaunchAtLogin else { return }
+        setPublishedLaunchAtLogin(enabled)
+        beginLaunchAtLoginUpdate(enabled)
+    }
+
+    /// Reconciles changes made directly in System Settings while the app remains running.
+    public func refreshLaunchAtLoginStatus() {
+        guard !isUpdatingLaunchAtLogin,
+              let statusProvider = loginService as? any LaunchAtLoginStatusProviding else { return }
+        applyLaunchAtLoginStatus(statusProvider.status)
+    }
+
+    private func beginLaunchAtLoginUpdate(_ enabled: Bool) {
+        guard !isUpdatingLaunchAtLogin else {
+            setPublishedLaunchAtLogin(confirmedLaunchAtLogin)
+            return
+        }
+        guard enabled != confirmedLaunchAtLogin else {
+            setPublishedLaunchAtLogin(confirmedLaunchAtLogin)
+            return
+        }
+
+        if enabled,
+           let statusProvider = loginService as? any LaunchAtLoginStatusProviding,
+           statusProvider.status == .requiresApproval {
+            applyLaunchAtLoginStatus(.requiresApproval)
+            return
+        }
+
+        setPublishedLaunchAtLogin(enabled)
+        launchAtLoginMessage = nil
+        isUpdatingLaunchAtLogin = true
+
+        let loginService = self.loginService
+        let confirmedBeforeUpdate = confirmedLaunchAtLogin
+        Task { [weak self] in
+            // `register`/`unregister` are blocking IPC calls. Keep them off the main actor and
+            // Swift's cooperative executor, then reconcile the framework's actual status.
+            let result = await Task.detached(priority: .userInitiated) {
+                do {
+                    try loginService.setEnabled(enabled)
+                    return LaunchAtLoginUpdateResult.success(
+                        Self.registrationStatus(for: loginService, fallbackEnabled: enabled)
+                    )
+                } catch {
+                    return LaunchAtLoginUpdateResult.failure(
+                        message: error.localizedDescription,
+                        status: Self.registrationStatus(
+                            for: loginService,
+                            fallbackEnabled: confirmedBeforeUpdate
+                        )
+                    )
+                }
+            }.value
+
+            guard let self else { return }
+            switch result {
+            case .success(let status):
+                self.applyLaunchAtLoginStatus(status)
+            case .failure(let message, let status):
+                self.applyLaunchAtLoginStatus(status, failureMessage: message)
+            }
+        }
+    }
+
+    private func applyLaunchAtLoginStatus(
+        _ status: LaunchAtLoginRegistrationStatus,
+        failureMessage: String? = nil
+    ) {
+        let enabled = status == .enabled
+        confirmedLaunchAtLogin = enabled
+        setPublishedLaunchAtLogin(enabled)
+        launchAtLoginMessage = failureMessage.map { "Could not update Launch at login: \($0)" }
+            ?? Self.message(for: status)
+        isUpdatingLaunchAtLogin = false
+        defaults.set(enabled, forKey: Keys.launchAtLogin)
+    }
+
+    private func setPublishedLaunchAtLogin(_ enabled: Bool) {
+        isApplyingLaunchAtLoginStatus = true
+        launchAtLogin = enabled
+        isApplyingLaunchAtLoginStatus = false
+    }
+
+    private nonisolated static func registrationStatus(
+        for service: any LaunchAtLoginService,
+        fallbackEnabled: Bool
+    ) -> LaunchAtLoginRegistrationStatus {
+        if let statusProvider = service as? any LaunchAtLoginStatusProviding {
+            return statusProvider.status
+        }
+        return fallbackEnabled ? .enabled : .disabled
+    }
+
+    private nonisolated static func message(
+        for status: LaunchAtLoginRegistrationStatus
+    ) -> String? {
+        switch status {
+        case .disabled, .enabled:
+            return nil
+        case .requiresApproval:
+            return "Allow ntfsmac in System Settings > General > Login Items."
+        case .unavailable:
+            return "Launch at login is unavailable for this app bundle."
+        }
     }
 
     /// GUI-PLAN.md "Preferences window" table's literal Default column.

--- a/gui/Tests/SettingsTests.swift
+++ b/gui/Tests/SettingsTests.swift
@@ -12,42 +12,176 @@ private func makeIsolatedDefaults(_ testName: String) -> UserDefaults {
     return defaults
 }
 
-private struct FakeLoginService: LaunchAtLoginService {
-    let shouldThrow: Bool
-    func setEnabled(_ enabled: Bool) throws {
-        if shouldThrow { throw NSError(domain: "test", code: 1) }
+private enum FakeLoginError: LocalizedError {
+    case registrationDenied
+
+    var errorDescription: String? { "registration denied" }
+}
+
+private final class FakeLoginService: LaunchAtLoginStatusProviding, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedStatus: LaunchAtLoginRegistrationStatus
+    private let enabledStatus: LaunchAtLoginRegistrationStatus
+    private let shouldThrow: Bool
+    private var calls: [Bool] = []
+
+    init(
+        status: LaunchAtLoginRegistrationStatus = .disabled,
+        enabledStatus: LaunchAtLoginRegistrationStatus = .enabled,
+        shouldThrow: Bool = false
+    ) {
+        storedStatus = status
+        self.enabledStatus = enabledStatus
+        self.shouldThrow = shouldThrow
     }
+
+    var status: LaunchAtLoginRegistrationStatus {
+        lock.withLock { storedStatus }
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        try lock.withLock {
+            calls.append(enabled)
+            if shouldThrow { throw FakeLoginError.registrationDenied }
+            storedStatus = enabled ? enabledStatus : .disabled
+        }
+    }
+
+    func replaceStatus(_ status: LaunchAtLoginRegistrationStatus) {
+        lock.withLock { storedStatus = status }
+    }
+
+    var requestedValues: [Bool] {
+        lock.withLock { calls }
+    }
+}
+
+/// Deliberately implements only the original protocol requirement. Its use here is a compile-time
+/// regression test for downstream conformers as well as a behavioral fallback test.
+private final class LegacyLoginService: LaunchAtLoginService, @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls: [Bool] = []
+
+    func setEnabled(_ enabled: Bool) {
+        lock.withLock { calls.append(enabled) }
+    }
+
+    var requestedValues: [Bool] {
+        lock.withLock { calls }
+    }
+}
+
+@MainActor
+private func waitForLaunchAtLoginUpdate(_ settings: Settings) async {
+    for _ in 0..<100 {
+        if !settings.isUpdatingLaunchAtLogin { return }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(!settings.isUpdatingLaunchAtLogin)
 }
 
 @MainActor
 @Test func defaultsMatchGuiPlanTable() {
     let defaults = makeIsolatedDefaults(#function)
-    let settings = Settings(defaults: defaults, loginService: FakeLoginService(shouldThrow: false))
+    let settings = Settings(defaults: defaults, loginService: LegacyLoginService())
 
     #expect(settings.launchAtLogin == false)
 }
 
 @MainActor
-@Test func settingsPersistAcrossInstancesWithSameDefaultsSuite() {
+@Test func legacyServicesKeepTheOriginalDefaultsBackedBehavior() async {
     let defaults = makeIsolatedDefaults(#function)
-    let first = Settings(defaults: defaults, loginService: FakeLoginService(shouldThrow: false))
+    defaults.set(true, forKey: "com.khr898.ntfsmac.settings.launchAtLogin")
+    let service = LegacyLoginService()
+    let settings = Settings(defaults: defaults, loginService: service)
 
-    first.launchAtLogin = true
+    #expect(settings.launchAtLogin)
 
-    let second = Settings(defaults: defaults, loginService: FakeLoginService(shouldThrow: false))
+    // Keep the original writable property API working, not only the new explicit UI method.
+    settings.launchAtLogin = false
+    await waitForLaunchAtLoginUpdate(settings)
 
-    #expect(second.launchAtLogin == true)
+    #expect(!settings.launchAtLogin)
+    #expect(service.requestedValues == [false])
+    #expect(!defaults.bool(forKey: "com.khr898.ntfsmac.settings.launchAtLogin"))
 }
 
 @MainActor
-@Test func launchAtLoginTogglesCallTheLoginService() {
+@Test func serviceManagementStatusOverridesAStalePersistedValue() {
     let defaults = makeIsolatedDefaults(#function)
-    // Failure from the real SMAppService call must not crash or block persistence — `didSet`
-    // uses `try?`, so this just documents that behavior rather than asserting a thrown error.
+    defaults.set(true, forKey: "com.khr898.ntfsmac.settings.launchAtLogin")
+
+    let settings = Settings(defaults: defaults, loginService: FakeLoginService(status: .disabled))
+
+    #expect(!settings.launchAtLogin)
+    #expect(!defaults.bool(forKey: "com.khr898.ntfsmac.settings.launchAtLogin"))
+}
+
+@MainActor
+@Test func launchAtLoginReadsBackSuccessfulRegistration() async {
+    let defaults = makeIsolatedDefaults(#function)
+    let service = FakeLoginService()
+    let settings = Settings(defaults: defaults, loginService: service)
+
+    settings.setLaunchAtLogin(true)
+    await waitForLaunchAtLoginUpdate(settings)
+
+    #expect(settings.launchAtLogin)
+    #expect(service.status == .enabled)
+    #expect(service.requestedValues == [true])
+    #expect(defaults.bool(forKey: "com.khr898.ntfsmac.settings.launchAtLogin"))
+}
+
+@MainActor
+@Test func launchAtLoginFailureRevertsTheSwitchAndSurfacesTheError() async {
+    let defaults = makeIsolatedDefaults(#function)
     let settings = Settings(defaults: defaults, loginService: FakeLoginService(shouldThrow: true))
 
-    settings.launchAtLogin = true
+    settings.setLaunchAtLogin(true)
+    await waitForLaunchAtLoginUpdate(settings)
 
-    #expect(settings.launchAtLogin == true)
-    #expect(defaults.bool(forKey: "com.khr898.ntfsmac.settings.launchAtLogin") == true)
+    #expect(!settings.launchAtLogin)
+    #expect(settings.launchAtLoginMessage?.contains("registration denied") == true)
+    #expect(!defaults.bool(forKey: "com.khr898.ntfsmac.settings.launchAtLogin"))
+}
+
+@MainActor
+@Test func pendingSystemApprovalDoesNotPretendRegistrationSucceeded() async {
+    let defaults = makeIsolatedDefaults(#function)
+    let settings = Settings(
+        defaults: defaults,
+        loginService: FakeLoginService(enabledStatus: .requiresApproval)
+    )
+
+    settings.setLaunchAtLogin(true)
+    await waitForLaunchAtLoginUpdate(settings)
+
+    #expect(!settings.launchAtLogin)
+    #expect(settings.launchAtLoginMessage?.contains("System Settings") == true)
+}
+
+@MainActor
+@Test func anExistingApprovalRequirementIsExplainedWithoutRegisteringAgain() {
+    let defaults = makeIsolatedDefaults(#function)
+    let service = FakeLoginService(status: .requiresApproval)
+    let settings = Settings(defaults: defaults, loginService: service)
+
+    settings.setLaunchAtLogin(true)
+
+    #expect(!settings.launchAtLogin)
+    #expect(settings.launchAtLoginMessage?.contains("System Settings") == true)
+    #expect(service.requestedValues.isEmpty)
+}
+
+@MainActor
+@Test func refreshReconcilesAChangeMadeInSystemSettings() {
+    let defaults = makeIsolatedDefaults(#function)
+    let service = FakeLoginService(status: .disabled)
+    let settings = Settings(defaults: defaults, loginService: service)
+
+    service.replaceStatus(.enabled)
+    settings.refreshLaunchAtLoginStatus()
+
+    #expect(settings.launchAtLogin)
+    #expect(defaults.bool(forKey: "com.khr898.ntfsmac.settings.launchAtLogin"))
 }


### PR DESCRIPTION
## Summary

This PR makes the Launch at login preference reflect the actual macOS Service Management registration instead of treating a persisted `UserDefaults` value as the source of truth.

It also presents the control using the native macOS switch style and provides clear feedback while registration is in progress, waiting for System Settings approval, unavailable, or unsuccessful.

## Problem

The existing preference could persist `true` before confirming that `SMAppService.mainApp.register()` had succeeded.

This allowed the displayed switch and stored value to diverge from the real system state in cases such as:

- registration failure;

- pending user approval in System Settings;

- the app bundle being unavailable to `SMAppService`;

- the registration being changed directly in System Settings while ntfsmac remained open.

The previous implementation also discarded registration errors, so the UI could appear enabled even when macOS had not registered the app.

## Implementation

- Adds `LaunchAtLoginRegistrationStatus` with explicit states for:

  - disabled;

  - enabled;

  - requires approval;

  - unavailable.

- Maps `SMAppService.mainApp.status` to those application-level states.

- Adds the optional `LaunchAtLoginStatusProviding` protocol for services capable of reporting their real registration status.

- Keeps `LaunchAtLoginService.setEnabled(_:)` unchanged.

- Keeps the existing writable `Settings.launchAtLogin` property available.

- Reconciles the initial switch value against the real Service Management status.

- Treats `UserDefaults` as a mirror of confirmed state rather than proof that registration succeeded.

- Reads the status again after every register or unregister attempt.

- Reverts the switch and displays the failure reason when registration fails.

- Explains when approval is required in:

  `System Settings > General > Login Items`.

- Refreshes the status whenever the Preferences view appears, including changes made outside the app.

- Runs the blocking Service Management IPC operation away from the main actor and Swift cooperative executor.

- Disables the switch only while an update is in progress.

- Shows a small progress indicator during registration changes.

- Uses SwiftUI's native `.switch` toggle style and adds an explicit accessibility label.

## Backward compatibility

The original `LaunchAtLoginService` protocol requirement remains unchanged. Existing or test-provided conformers are not required to implement the new status protocol.

Services that only implement the original protocol retain the previous `UserDefaults`-backed behavior. This provides both a source-compatibility check and a fallback for injected legacy services.

The original writable `launchAtLogin` API also remains functional, so existing callers do not need to migrate to the new explicit UI method.

## Scope and safety

- Continues using `SMAppService.mainApp`, which matches the existing macOS 13.0 deployment target.

- Does not use the deprecated `SMLoginItemSetEnabled`.

- Does not introduce a separate login helper or launch daemon.

- Does not modify the privileged SMJobBless/XPC helper.

- Does not change mount, unmount, NFS, `pf`, route, or device-validation behavior.

- Does not change signing, entitlements, or packaging.

- Does not add a dependency.

This is a focused follow-up to the `GUI-PLAN.md` Preferences window and the Phase 3 `3-preferences` unit.

## Testing

Validated directly on commit `5c1191d`, rebuilt as one focused commit on upstream `v1.1.020826` (`02678db`):

- `git diff --check upstream/main...HEAD`

- `swift test --disable-sandbox`

- Full test suite: **165 tests passed**

The launch-at-login tests cover:

- documented default behavior;

- compatibility with services implementing only the original protocol;

- real Service Management status overriding stale persisted state;

- successful registration and read-back;

- registration failure, switch rollback, and visible error reporting;

- pending System Settings approval;

- avoiding duplicate registration while approval is already pending;

- reconciliation after a status change made outside the application.

The rebuilt branch is compatible with upstream's ext2/ext3/ext4 and multiple-concurrent-mount changes. The only build diagnostics are the repository's pre-existing `SMJobCopyDictionary` and `SMJobBless` deprecation warnings; this PR introduces no new warnings.
