### PR TITLE
fix(gui): use adaptive tint for idle menu icon

### DIFF
--- a/GUI-PLAN.md
+++ b/GUI-PLAN.md
@@ -19,11 +19,16 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 
 | Colour | Meaning |
 |--------|---------|
-| Grey | Idle, nothing mounted |
+| System-adaptive | Idle, nothing mounted |
 | Blue (pulsing) | Mounting |
 | Green | Mounted read/write |
 | Yellow | Mounted **read-only** (dirty journal) |
 | Red | Error |
+
+The idle SF Symbol is an AppKit template image, so macOS supplies the same contrasting tint used
+by native menu-bar apps. This keeps the icon visible across light and dark menu-bar backgrounds
+without adding a preference or first-run animation. Saturated colours remain reserved for real
+mounting, mounted, warning, and error states.
 
 ---
 

--- a/docs/dev/SHARED_TASK_NOTES.md
+++ b/docs/dev/SHARED_TASK_NOTES.md
@@ -348,6 +348,12 @@ resolved.
       still SPM only, no Xcode project; actual `.app` bundle assembly (embedding this Info.plist,
       icon, code signing) is packaging work for a later script, not part of this unit's
       acceptance (compiles + tests pass).
+      **Adaptive idle-icon follow-up:** the idle SF Symbol is now rendered as an AppKit template
+      image, letting macOS select a contrasting tint for the current menu-bar background just as
+      it does for native menu extras. This fixes the icon disappearing against some light or dark
+      wallpapers without adding appearance preferences or first-launch animation state. Blue,
+      green, yellow, and red remain explicit non-template status colours; tests assert both sides
+      of that boundary and the macOS 13 deployment floor is unchanged.
 - [x] `3-drive-detect` — `gui/Drives/DriveScanner.swift`, `gui/Views/DriveRow.swift`,
       `gui/Tests/DriveScannerTests.swift`. **Real contract checked before coding:** `ListCmd`
       (`cli.rs`) has no `--json` flag (same finding `3-xpc-helper` already made) — output is

--- a/gui/App/NtfsmacApp.swift
+++ b/gui/App/NtfsmacApp.swift
@@ -91,17 +91,16 @@ struct NtfsmacApp: App {
             // `ui/prototype.html`'s red menu-bar icon ("Error — Helper Missing", comp lines
             // 636-657) is driven by the helper install outcome, not `AppState.state` — these were
             // previously fully decoupled, so a denied/failed helper install left the icon grey.
-            HStack(spacing: 3) {
-                StatusIconView(state: helperInstaller.state.isDeniedOrFailed ? .error : appState.state)
-            }
-            .task { driveScanner.startPolling() }
-            .task(id: helperInstaller.state) {
-                if helperInstaller.state == .installing || helperInstaller.state == .notChecked {
-                    cliAutoStager.reset()
+            StatusIconView(state: helperInstaller.state.isDeniedOrFailed ? .error : appState.state)
+                .accessibilityLabel("ntfsmac")
+                .task { driveScanner.startPolling() }
+                .task(id: helperInstaller.state) {
+                    if helperInstaller.state == .installing || helperInstaller.state == .notChecked {
+                        cliAutoStager.reset()
+                    }
+                    guard helperInstaller.state == .installed else { return }
+                    await cliAutoStager.stageIfNeeded()
                 }
-                guard helperInstaller.state == .installed else { return }
-                await cliAutoStager.stageIfNeeded()
-            }
         }
         .menuBarExtraStyle(.window)
     }

--- a/gui/Status/StatusIcon.swift
+++ b/gui/Status/StatusIcon.swift
@@ -1,24 +1,16 @@
 import AppKit
 import SwiftUI
 
-// ponytail: MenuBarExtra's label doesn't rasterize into the real NSStatusItem for
-// Image(systemName:) directly (confirmed live: icon vanishes entirely) — same class of bug
-// commit e762f6d fixed for the old Canvas glyph. Pre-rendering to NSImage via ImageRenderer
-// is the proven fix; reapplying it here for the new SF-Symbol glyph.
-
 public struct StatusIconStyle: Equatable {
     public let color: Color
     public let isIdle: Bool
     public let isPulsing: Bool
 }
 
-/// GUI-PLAN.md "Menu-bar icon states" table, exact mapping:
-/// grey=idle, blue(pulsing)=mounting, green=rw, yellow=ro-dirty, red=error.
-/// Literal hex values from `ui/prototype.html` (`Colors.swift`) — idle uses `.ntfsIdleGray`
-/// (system secondary-label gray in light mode, pure white in dark mode) rather than a custom
-/// brand hex: the comp only draws translucent white/black there, and `.secondary`'s own
-/// dark-mode gray reads too faintly against a dark desktop background. Every other state below
-/// keeps its exact saturated brand color unchanged in both appearances.
+/// GUI-PLAN.md "Menu-bar icon states" mapping. Idle retains `.ntfsIdleGray` as its semantic
+/// fallback, while `StatusIconView` presents that state as a native template image so macOS can
+/// choose the contrasting menu-bar tint. Every active/error state keeps its exact saturated
+/// project colour in both appearances.
 public enum StatusIcon {
     public static func style(for state: MountState) -> StatusIconStyle {
         switch state {
@@ -44,12 +36,11 @@ public enum StatusIcon {
 /// Menu-bar label view. Uses the same SF Symbol (`externaldrive.fill`) as the rest of the app's
 /// drive icons (`DriveHeaderGlyph`/`DriveRowGlyph`, `gui/Style/Icons.swift`) — explicit product
 /// decision to match the app's standard icon rather than keep a one-off custom glyph here.
-/// `Image(systemName:)` is one of the two content types `MenuBarExtra`'s label reliably
-/// rasterizes into the real `NSStatusItem` button (confirmed empirically earlier: a bare `Text`
-/// or `Image` renders, a bare `Rectangle`/custom `Canvas` does not) — no `ImageRenderer`
-/// pre-rendering workaround needed here, unlike the literal comp-transcribed glyphs elsewhere.
-/// Pulsing is a plain opacity animation, not `.symbolEffect` (SF Symbols 5, macOS 14+/
-/// Sonoma-only) — this project's floor is macOS 13.0.
+/// The idle glyph is an AppKit template image, matching native menu-bar apps: macOS supplies the
+/// correct contrasting tint for the current menu-bar background. Non-idle states keep the
+/// GUI-PLAN status colours and are pre-rendered because `MenuBarExtra` does not reliably apply a
+/// SwiftUI foreground style to its real `NSStatusItem`. Pulsing uses opacity rather than the
+/// macOS 14-only `.symbolEffect`, preserving the macOS 13 deployment floor.
 public struct StatusIconView: View {
     let state: MountState
     @State private var isDim = false
@@ -60,7 +51,7 @@ public struct StatusIconView: View {
 
     public var body: some View {
         let style = StatusIcon.style(for: state)
-        Image(nsImage: Self.renderedGlyph(color: style.color))
+        Image(nsImage: Self.renderedGlyph(for: style))
             .opacity(style.isPulsing && isDim ? 0.4 : 1.0)
             .onAppear {
                 guard style.isPulsing else { return }
@@ -70,13 +61,28 @@ public struct StatusIconView: View {
             }
     }
 
-    private static func renderedGlyph(color: Color) -> NSImage {
+    static func renderedGlyph(for style: StatusIconStyle) -> NSImage {
+        if style.isIdle {
+            return templateGlyph()
+        }
+
         let renderer = ImageRenderer(content:
             Image(systemName: "externaldrive.fill")
                 .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(color)
+                .foregroundStyle(style.color)
         )
         renderer.scale = NSScreen.main?.backingScaleFactor ?? 2
         return renderer.nsImage ?? NSImage(size: NSSize(width: 15, height: 12))
+    }
+
+    private static func templateGlyph() -> NSImage {
+        let configuration = NSImage.SymbolConfiguration(pointSize: 15, weight: .medium)
+        let symbol = NSImage(
+            systemSymbolName: "externaldrive.fill",
+            accessibilityDescription: "ntfsmac"
+        )?.withSymbolConfiguration(configuration)
+        let image = (symbol?.copy() as? NSImage) ?? NSImage(size: NSSize(width: 15, height: 12))
+        image.isTemplate = true
+        return image
     }
 }

--- a/gui/Tests/StatusIconTests.swift
+++ b/gui/Tests/StatusIconTests.swift
@@ -2,11 +2,9 @@ import SwiftUI
 import Testing
 @testable import NtfsmacGUI
 
-// GUI-PLAN.md "Menu-bar icon states": grey=idle, blue(pulsing)=mounting, green=rw,
-// yellow=ro-dirty, red=error. Asserts all five, per this unit's acceptance clause.
-// Colors are `3-liquid-glass`'s literal hex values (`Colors.swift`) — idle uses `.ntfsIdleGray`
-// (secondary-label gray in light mode, pure white in dark mode — `.secondary` alone read too
-// faint against a dark desktop background).
+// GUI-PLAN.md "Menu-bar icon states": system-adaptive=idle, blue(pulsing)=mounting,
+// green=rw, yellow=ro-dirty, red=error. The pure style mapping retains `.ntfsIdleGray` as a
+// fallback; the rendered idle glyph is a template so AppKit chooses its real menu-bar tint.
 
 @Test func idleIsGrayAndNotPulsing() {
     let style = StatusIcon.style(for: .idle)
@@ -42,4 +40,20 @@ import Testing
     let style = StatusIcon.style(for: .error)
     #expect(style.color == .ntfsRed)
     #expect(!style.isPulsing)
+}
+
+@MainActor
+@Test func idleGlyphUsesTheSystemMenuBarTint() {
+    let image = StatusIconView.renderedGlyph(for: StatusIcon.style(for: .idle))
+
+    #expect(image.isTemplate)
+    #expect(image.size.width > 0)
+    #expect(image.size.height > 0)
+}
+
+@MainActor
+@Test func colouredStatusGlyphIsNotConvertedToATemplate() {
+    let image = StatusIconView.renderedGlyph(for: StatusIcon.style(for: .error))
+
+    #expect(!image.isTemplate)
 }


### PR DESCRIPTION
## Summary

This PR renders the idle ntfsmac menu-bar icon as a native AppKit template image, allowing macOS to select the appropriate contrasting tint for the current menu-bar background.

The change fixes cases where the idle icon becomes difficult or impossible to see against light, dark, or wallpaper-dependent menu-bar backgrounds.

## Problem

The idle icon previously relied on an explicitly rendered color. A fixed color cannot account reliably for every menu-bar background macOS may produce, especially when desktop wallpaper, appearance, transparency, and contrast settings interact.

This could leave ntfsmac running correctly but make its menu-bar entry appear missing.

## Why a template image

Template images are the native macOS mechanism for monochrome menu-bar icons. AppKit applies the same system-managed contrasting tint used by other native menu extras.

Using that mechanism avoids introducing:

- separate light and dark icon assets;
- an appearance preference;
- first-launch animation state;
- wallpaper detection;
- manual theme observers;
- additional persistence or migration logic.

The result is smaller, follows platform conventions, and adapts automatically when the menu-bar appearance changes.

## Implementation

- Creates the idle `externaldrive.fill` symbol as an `NSImage`.
- Applies the existing 15-point, medium-weight symbol configuration.
- Marks only the idle image as an AppKit template image.
- Keeps all meaningful status colours explicitly rendered as non-template images:
  - blue and pulsing while mounting;
  - green when mounted read/write;
  - green for a deliberate read-only mount;
  - yellow for a dirty-journal read-only mount;
  - red for an error.
- Preserves the existing opacity-based mounting pulse.
- Adds an accessibility description to the symbol and an accessibility label to the menu-bar view.
- Removes an unnecessary single-child `HStack` from the `MenuBarExtra` label.
- Updates `GUI-PLAN.md` so the documented idle state is system-adaptive rather than fixed grey.
- Records the design decision in the shared development notes.

## Compatibility and scope

- Preserves the macOS 13.0 deployment target.
- Does not use the macOS 14-only `.symbolEffect` API.
- Does not add settings, first-run state, stored preferences, or migrations.
- Does not change the underlying mount-state mapping.
- Does not change the active, warning, or error colours.
- Does not modify the CLI, privileged helper, XPC boundary, mount workflow, or packaging.
- Does not add a dependency.

This is a focused follow-up to the `GUI-PLAN.md` Menu-bar icon states table and the Phase 3 `3-menubar-shell` / `3-liquid-glass` work.

## Testing

Validated directly on commit `10e2ba3`, rebuilt as one focused commit on upstream `v1.1.020826` (`02678db`):

- `git diff --check upstream/main...HEAD`
- `swift test --disable-sandbox`
- Full test suite: **162 tests passed**

The status-icon tests verify:

- the complete idle, mounting, mounted, warning, and error state mapping;
- that the idle glyph is a valid, non-empty template image;
- that coloured status glyphs remain non-template images;
- that the mounting state retains its pulsing behavior.

The rebuilt branch is compatible with upstream's ext2/ext3/ext4 and multiple-concurrent-mount changes. The only build diagnostics are the repository's pre-existing `SMJobCopyDictionary` and `SMJobBless` deprecation warnings; this PR introduces no new warnings.
