### PR TITLE
fix(gui): prevent duplicate app instances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
             exclude: ["App", "Resources", "Info.plist", "Tests"],
             sources: [
                 "Helper/HelperClient.swift", "Status/StatusIcon.swift", "State/AppState.swift",
+                "State/SingleInstanceGuard.swift",
                 "Drives/DriveScanner.swift", "Views/DriveRow.swift", "Actions/MountController.swift",
                 "Drives/ThroughputMonitor.swift", "Views/SpeedBar.swift",
                 "Actions/RemountController.swift", "Views/DirtyBanner.swift",

--- a/docs/dev/SHARED_TASK_NOTES.md
+++ b/docs/dev/SHARED_TASK_NOTES.md
@@ -676,6 +676,14 @@ units remain in PLAN.md's task list for Phase 3.
   auto-mount-on-detect, only the manual button, which always mounts read-write via ntfs-3g) —
   pre-existing gap in `MountController`'s own public API from `3-mount-unmount`, not this
   changeset's job to fix; flagging again so it isn't lost.
+- **Single-instance GUI guard** — the app delegate now acquires an atomic per-user open-file-
+  description lock before the SwiftUI scene starts running its polling and menu-bar tasks. A
+  forced second launch exits before it can start a concurrent GUI workflow; an unavailable lock
+  fails closed. The implementation uses the public `fcntl(F_OFD_SETLK)` interface available on
+  macOS 13, keeps the lock descriptor close-on-exec, and never touches the helper/XPC privilege
+  boundary. Swift Testing covers lock contention, deterministic/idempotent release, filesystem
+  failures, default path construction, and user-facing errors; line coverage for
+  `SingleInstanceGuard.swift` is 88.46%.
 - **App icon** — `gui/Resources/AppIcon.icns` (+ `AppIcon-source.png`, `gen_icon.py`), wired via
   `Info.plist`'s `CFBundleIconFile`. White external-drive + connect-arrow glyph (reuses this
   project's own already-established icon language — same motif as `ui/prototype.html`'s SVGs and

--- a/gui/App/NtfsmacApp.swift
+++ b/gui/App/NtfsmacApp.swift
@@ -1,11 +1,36 @@
-import SwiftUI
+import AppKit
 import NtfsmacGUI
+import SwiftUI
+import os.log
+
+private let lifecycleLog = Logger(subsystem: "com.khr898.ntfsmac", category: "Lifecycle")
+
+final class NtfsmacApplicationDelegate: NSObject, NSApplicationDelegate {
+    private var singleInstanceGuard: SingleInstanceGuard?
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        do {
+            singleInstanceGuard = try SingleInstanceGuard()
+        } catch SingleInstanceGuardError.alreadyRunning {
+            lifecycleLog.notice("A second GUI instance was blocked")
+            NSApplication.shared.terminate(nil)
+        } catch {
+            // Fail closed: two active GUI workflows are riskier than declining to launch when
+            // the per-user lock cannot be acquired.
+            lifecycleLog.error(
+                "Unable to acquire the GUI instance lock: \(error.localizedDescription, privacy: .public)"
+            )
+            NSApplication.shared.terminate(nil)
+        }
+    }
+}
 
 /// Menu-bar agent (LSUIElement=true in Info.plist — no Dock icon, no main window). `MenuBarExtra`
 /// (macOS 13+, native) covers the icon+popover shell. Feature content is `PopoverContentView`
 /// (`gui/Views/PopoverContentView.swift`), which composes every Phase 3 feature unit into one view.
 @main
 struct NtfsmacApp: App {
+    @NSApplicationDelegateAdaptor(NtfsmacApplicationDelegate.self) private var applicationDelegate
     @StateObject private var appState: AppState
     @StateObject private var driveScanner: DriveScanner
     @StateObject private var mountController: MountController

--- a/gui/State/SingleInstanceGuard.swift
+++ b/gui/State/SingleInstanceGuard.swift
@@ -1,0 +1,100 @@
+import Darwin
+import Foundation
+
+public enum SingleInstanceGuardError: Error, Equatable, LocalizedError {
+    case alreadyRunning
+    case unavailable(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .alreadyRunning:
+            return "Another ntfsmac instance is already running."
+        case .unavailable(let reason):
+            return "The ntfsmac instance lock is unavailable: \(reason)"
+        }
+    }
+}
+
+/// Holds an atomic, per-user file lock for the lifetime of the GUI process.
+///
+/// Open-file-description locks conflict across independently opened descriptors, including two
+/// app launches racing at the same time. Closing the descriptor releases the lock automatically;
+/// the harmless lock file remains so no cleanup race can let a second process through.
+public final class SingleInstanceGuard {
+    public let lockFileURL: URL
+
+    private var fileDescriptor: Int32?
+
+    public convenience init(fileManager: FileManager = .default) throws {
+        try self.init(
+            lockFileURL: Self.defaultLockFileURL(fileManager: fileManager),
+            fileManager: fileManager
+        )
+    }
+
+    public init(lockFileURL: URL, fileManager: FileManager = .default) throws {
+        self.lockFileURL = lockFileURL
+
+        do {
+            try fileManager.createDirectory(
+                at: lockFileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw SingleInstanceGuardError.unavailable(error.localizedDescription)
+        }
+
+        let descriptor = lockFileURL.path.withCString {
+            Darwin.open($0, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        }
+        guard descriptor >= 0 else {
+            throw SingleInstanceGuardError.unavailable(Self.posixErrorDescription())
+        }
+
+        guard Self.setLock(on: descriptor, type: Int16(F_WRLCK)) == 0 else {
+            let lockError = errno
+            Darwin.close(descriptor)
+            if lockError == EAGAIN || lockError == EACCES {
+                throw SingleInstanceGuardError.alreadyRunning
+            }
+            throw SingleInstanceGuardError.unavailable(String(cString: strerror(lockError)))
+        }
+
+        fileDescriptor = descriptor
+    }
+
+    deinit {
+        release()
+    }
+
+    /// Releases the lock deterministically. Repeated calls are safe.
+    public func release() {
+        guard let descriptor = fileDescriptor else { return }
+        fileDescriptor = nil
+        _ = Self.setLock(on: descriptor, type: Int16(F_UNLCK))
+        Darwin.close(descriptor)
+    }
+
+    public static func defaultLockFileURL(fileManager: FileManager = .default) -> URL {
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return base
+            .appendingPathComponent("ntfsmac", isDirectory: true)
+            .appendingPathComponent("gui-instance.lock", isDirectory: false)
+    }
+
+    private static func setLock(on descriptor: Int32, type: Int16) -> Int32 {
+        var lock = flock(
+            l_start: 0,
+            l_len: 0,
+            l_pid: 0,
+            l_type: type,
+            l_whence: Int16(SEEK_SET)
+        )
+        return Darwin.fcntl(descriptor, F_OFD_SETLK, &lock)
+    }
+
+    private static func posixErrorDescription() -> String {
+        String(cString: strerror(errno))
+    }
+}

--- a/gui/Tests/SingleInstanceGuardTests.swift
+++ b/gui/Tests/SingleInstanceGuardTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import NtfsmacGUI
+
+private func makeGuardTestDirectory(_ testName: String) throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ntfsmac-instance-tests-\(testName)-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
+@Test func aSecondGuiInstanceCannotAcquireTheSameLock() throws {
+    let directory = try makeGuardTestDirectory(#function)
+    let lockFile = directory.appendingPathComponent("instance.lock")
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let first = try SingleInstanceGuard(lockFileURL: lockFile)
+
+    #expect(throws: SingleInstanceGuardError.alreadyRunning) {
+        try SingleInstanceGuard(lockFileURL: lockFile)
+    }
+
+    first.release()
+}
+
+@Test func releasingTheGuardIsIdempotentAndAllowsAReplacement() throws {
+    let directory = try makeGuardTestDirectory(#function)
+    let lockFile = directory.appendingPathComponent("instance.lock")
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let first = try SingleInstanceGuard(lockFileURL: lockFile)
+    first.release()
+    first.release()
+
+    let replacement = try SingleInstanceGuard(lockFileURL: lockFile)
+    replacement.release()
+}
+
+@Test func aParentPathThatIsAFileIsRejected() throws {
+    let directory = try makeGuardTestDirectory(#function)
+    let parentFile = directory.appendingPathComponent("not-a-directory")
+    let lockFile = parentFile.appendingPathComponent("instance.lock")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try Data().write(to: parentFile)
+
+    #expect(throws: SingleInstanceGuardError.self) {
+        try SingleInstanceGuard(lockFileURL: lockFile)
+    }
+}
+
+@Test func aDirectoryCannotBeUsedAsTheLockFile() throws {
+    let directory = try makeGuardTestDirectory(#function)
+    let lockFile = directory.appendingPathComponent("instance.lock")
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try FileManager.default.createDirectory(at: lockFile, withIntermediateDirectories: false)
+
+    #expect(throws: SingleInstanceGuardError.self) {
+        try SingleInstanceGuard(lockFileURL: lockFile)
+    }
+}
+
+@Test func errorsHavePlainLanguageDescriptions() {
+    #expect(SingleInstanceGuardError.alreadyRunning.errorDescription?.contains("already running") == true)
+    #expect(SingleInstanceGuardError.unavailable("permission denied").errorDescription?.contains("permission denied") == true)
+}
+
+@Test func defaultLockPathUsesTheUserApplicationSupportDirectory() {
+    let url = SingleInstanceGuard.defaultLockFileURL()
+
+    #expect(url.lastPathComponent == "gui-instance.lock")
+    #expect(url.deletingLastPathComponent().lastPathComponent == "ntfsmac")
+}


### PR DESCRIPTION
Summary

- acquire an atomic per-user GUI lock during `applicationWillFinishLaunching`, before polling or
  menu-bar tasks begin
- back the guard with an open-file-description lock and retain the descriptor for process lifetime
- keep the lock under the user's Application Support directory with user-only permissions,
  `O_CLOEXEC`, and `O_NOFOLLOW`
- fail closed when the lock cannot be created or acquired
- preserve the CLI, helper/XPC privilege boundary, mount workflow, signing, and packaging

The lock belongs to the open descriptor rather than a PID stored in the file, so the harmless lock
file cannot create a stale-lock condition after the owning process exits.

### Verification

- commit `cc557e38e8ddc909bf23b7121fcc4fbe926782ae`
- `git diff --check upstream/main...HEAD` — passed
- full Swift suite — 166 tests passed
- fork `Package DMG` workflow — passed
- duplicate-launch live check — passed