### PR TITLE
fix(gui): clarify diagnostic status context

### DIFF
--- a/GUI-PLAN.md
+++ b/GUI-PLAN.md
@@ -84,6 +84,15 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 | `Retry` | Re-attempt last action |
 | `Diagnose` | Jump to diagnostics |
 
+### Diagnostic summary
+
+Diagnostic rows distinguish confirmed health, expected or transitional information, actionable
+warnings, and unavailable context. A stopped vmnet bridge is informational while ntfsmac is idle
+or starting a mount; it becomes a warning only when a drive is already mounted and the private NFS
+network is expected to be active. Unknown or malformed values are shown neutrally rather than as
+confirmed failures. Short explanations remain available through native help and accessibility
+text without widening the popover.
+
 ### Preferences window
 
 | Control | Type | Default |

--- a/gui/Tests/DiagnoseRunnerTests.swift
+++ b/gui/Tests/DiagnoseRunnerTests.swift
@@ -35,9 +35,9 @@ private final class FakeRunner: PrivilegedCommandRunning {
 
     #expect(rows.count == 4)
     #expect(rows.allSatisfy { $0.isHealthy })
-    #expect(rows.first(where: { $0.id == "binaries" })?.value == "all present")
-    #expect(rows.first(where: { $0.id == "kernel" })?.value == "match")
-    #expect(rows.first(where: { $0.id == "bridge" })?.value == "up")
+    #expect(rows.first(where: { $0.id == "binaries" })?.value == "All present")
+    #expect(rows.first(where: { $0.id == "kernel" })?.value == "Match")
+    #expect(rows.first(where: { $0.id == "bridge" })?.value == "Active")
 }
 
 @Test func degradedReportProducesUnhealthyRowsWithCounts() {
@@ -45,11 +45,53 @@ private final class FakeRunner: PrivilegedCommandRunning {
     let rows = DiagnoseSummary.rows(for: report)
 
     #expect(rows.count == 4)
-    #expect(rows.allSatisfy { !$0.isHealthy })
     #expect(rows.first(where: { $0.id == "binaries" })?.value == "2 missing")
     #expect(rows.first(where: { $0.id == "quarantine" })?.value == "1 quarantined")
-    #expect(rows.first(where: { $0.id == "kernel" })?.value == "mismatch")
-    #expect(rows.first(where: { $0.id == "bridge" })?.value == "down")
+    #expect(rows.first(where: { $0.id == "kernel" })?.status == .warning)
+    #expect(rows.first(where: { $0.id == "bridge" })?.status == .unavailable)
+}
+
+@Test(arguments: ["match", "mismatch", "missing", "unknown", "malformed"])
+func kernelPinRawValuesAreRepresentedHonestly(rawValue: String) {
+    let report = DiagnoseReport(healthy: false, missingBinaries: 0, quarantinedBinaries: 0, kernelPin: rawValue, bridge: "up")
+    let row = DiagnoseSummary.rows(for: report).first { $0.id == "kernel" }!
+
+    let expected: DiagnoseStatus = rawValue == "match" ? .healthy : (["mismatch", "missing"].contains(rawValue) ? .warning : .unavailable)
+    #expect(row.status == expected)
+    #expect((rawValue == "unknown" || rawValue == "malformed") ? row.value == "Unknown" : true)
+}
+
+@Test(arguments: [
+    (MountState.idle, DiagnoseStatus.informational, "Idle — starts when a drive is mounted"),
+    (.mounting, .informational, "Starting with the mount"),
+    (.mountedReadWrite, .warning, "Inactive while a drive is mounted"),
+    (.mountedReadOnly, .warning, "Inactive while a drive is mounted"),
+    (.mountedReadOnlyDirty, .warning, "Inactive while a drive is mounted"),
+    (.error, .unavailable, "Inactive — mount context unavailable"),
+])
+func bridgeDownUsesMountContext(argument: (MountState, DiagnoseStatus, String)) {
+    let report = DiagnoseReport(healthy: true, missingBinaries: 0, quarantinedBinaries: 0, kernelPin: "match", bridge: "down")
+    let row = DiagnoseSummary.rows(for: report, mountState: argument.0).first { $0.id == "bridge" }!
+
+    #expect(row.status == argument.1)
+    #expect(row.value == argument.2)
+}
+
+@Test func bridgeDownWithoutKnownMountContextIsNeutralRatherThanWarning() {
+    let report = DiagnoseReport(healthy: true, missingBinaries: 0, quarantinedBinaries: 0, kernelPin: "match", bridge: "down")
+    let row = DiagnoseSummary.rows(for: report).first { $0.id == "bridge" }!
+
+    #expect(row.status == .unavailable)
+    #expect(!row.isHealthy)
+}
+
+@Test func malformedCountsAndBridgeAreUnavailable() {
+    let report = DiagnoseReport(healthy: false, missingBinaries: -1, quarantinedBinaries: -1, kernelPin: "match", bridge: "starting")
+    let rows = DiagnoseSummary.rows(for: report, mountState: .mountedReadWrite)
+
+    #expect(rows.first { $0.id == "binaries" }?.status == .unavailable)
+    #expect(rows.first { $0.id == "quarantine" }?.status == .unavailable)
+    #expect(rows.first { $0.id == "bridge" }?.status == .unavailable)
 }
 
 @MainActor

--- a/gui/Views/DiagnosePanel.swift
+++ b/gui/Views/DiagnosePanel.swift
@@ -1,12 +1,26 @@
 import SwiftUI
 
+/// Diagnostics need more than a healthy/unhealthy Boolean. In particular, a stopped vmnet
+/// bridge is expected while ntfsmac is idle, while an unknown raw value must not be presented as
+/// a confirmed failure.
+public enum DiagnoseStatus: String, Equatable, Sendable {
+    case healthy
+    case informational
+    case warning
+    case unavailable
+}
+
 /// Plain-language summary row (this unit's Do clause: "render a plain-language summary" — not
 /// a raw JSON/log dump).
 public struct DiagnoseSummaryRow: Equatable, Sendable, Identifiable {
     public let id: String
     public let label: String
     public let value: String
-    public let isHealthy: Bool
+    public let status: DiagnoseStatus
+    public let explanation: String
+
+    /// Retained for source compatibility with callers that only distinguish confirmed health.
+    public var isHealthy: Bool { status == .healthy }
 }
 
 /// Pure mapping from the real `DiagnoseReport` JSON shape to display rows — separated from the
@@ -14,32 +28,81 @@ public struct DiagnoseSummaryRow: Equatable, Sendable, Identifiable {
 /// assert on parsed rows without a SwiftUI view-inspection dependency.
 public enum DiagnoseSummary {
     public static func rows(for report: DiagnoseReport) -> [DiagnoseSummaryRow] {
+        rows(for: report, mountState: nil)
+    }
+
+    public static func rows(for report: DiagnoseReport, mountState: MountState?) -> [DiagnoseSummaryRow] {
         [
-            DiagnoseSummaryRow(
-                id: "binaries",
-                label: "Vendor binaries",
-                value: report.missingBinaries == 0 ? "all present" : "\(report.missingBinaries) missing",
-                isHealthy: report.missingBinaries == 0
-            ),
-            DiagnoseSummaryRow(
-                id: "quarantine",
-                label: "Quarantine",
-                value: report.quarantinedBinaries == 0 ? "clear" : "\(report.quarantinedBinaries) quarantined",
-                isHealthy: report.quarantinedBinaries == 0
-            ),
-            DiagnoseSummaryRow(
-                id: "kernel",
-                label: "Kernel pin",
-                value: report.kernelPin,
-                isHealthy: report.kernelPin == "match"
-            ),
-            DiagnoseSummaryRow(
-                id: "bridge",
-                label: "vmnet bridge",
-                value: report.bridge,
-                isHealthy: report.bridge == "up"
-            ),
+            binariesRow(missingCount: report.missingBinaries),
+            quarantineRow(quarantinedCount: report.quarantinedBinaries),
+            kernelRow(rawValue: report.kernelPin),
+            bridgeRow(rawValue: report.bridge, mountState: mountState),
         ]
+    }
+
+    private static func binariesRow(missingCount: Int) -> DiagnoseSummaryRow {
+        let explanation = "These are the four runtime components required by ntfsmac. Missing components require installation or repair."
+        guard missingCount >= 0 else {
+            return .init(id: "binaries", label: "Vendor binaries", value: "Unknown", status: .unavailable, explanation: explanation)
+        }
+        return .init(
+            id: "binaries",
+            label: "Vendor binaries",
+            value: missingCount == 0 ? "All present" : "\(missingCount) missing",
+            status: missingCount == 0 ? .healthy : .warning,
+            explanation: explanation
+        )
+    }
+
+    private static func quarantineRow(quarantinedCount: Int) -> DiagnoseSummaryRow {
+        let explanation = "macOS quarantine can prevent downloaded runtime components from executing."
+        guard quarantinedCount >= 0 else {
+            return .init(id: "quarantine", label: "Quarantine", value: "Unknown", status: .unavailable, explanation: explanation)
+        }
+        return .init(
+            id: "quarantine",
+            label: "Quarantine",
+            value: quarantinedCount == 0 ? "Clear" : "\(quarantinedCount) quarantined",
+            status: quarantinedCount == 0 ? .healthy : .warning,
+            explanation: explanation
+        )
+    }
+
+    private static func kernelRow(rawValue: String) -> DiagnoseSummaryRow {
+        let explanation = "The installed kernel module bundle is checked against the exact version tested by the project."
+        switch rawValue {
+        case "match":
+            return .init(id: "kernel", label: "Kernel pin", value: "Match", status: .healthy, explanation: explanation)
+        case "mismatch":
+            return .init(id: "kernel", label: "Kernel pin", value: "Mismatch", status: .warning, explanation: explanation)
+        case "missing":
+            return .init(id: "kernel", label: "Kernel pin", value: "Missing", status: .warning, explanation: explanation)
+        case "unknown":
+            return .init(id: "kernel", label: "Kernel pin", value: "Unknown", status: .unavailable, explanation: explanation)
+        default:
+            return .init(id: "kernel", label: "Kernel pin", value: "Unknown", status: .unavailable, explanation: explanation)
+        }
+    }
+
+    private static func bridgeRow(rawValue: String, mountState: MountState?) -> DiagnoseSummaryRow {
+        let explanation = "ntfsmac's private host-only network carries NFS traffic between macOS and the microVM."
+        guard rawValue == "down" else {
+            if rawValue == "up" {
+                return .init(id: "bridge", label: "vmnet bridge", value: "Active", status: .healthy, explanation: explanation)
+            }
+            return .init(id: "bridge", label: "vmnet bridge", value: "Unknown", status: .unavailable, explanation: explanation)
+        }
+
+        switch mountState {
+        case .idle:
+            return .init(id: "bridge", label: "vmnet bridge", value: "Idle — starts when a drive is mounted", status: .informational, explanation: explanation)
+        case .mounting:
+            return .init(id: "bridge", label: "vmnet bridge", value: "Starting with the mount", status: .informational, explanation: explanation)
+        case .mountedReadWrite, .mountedReadOnly, .mountedReadOnlyDirty:
+            return .init(id: "bridge", label: "vmnet bridge", value: "Inactive while a drive is mounted", status: .warning, explanation: explanation)
+        case .error, .none:
+            return .init(id: "bridge", label: "vmnet bridge", value: "Inactive — mount context unavailable", status: .unavailable, explanation: explanation)
+        }
     }
 }
 
@@ -47,19 +110,28 @@ public enum DiagnoseSummary {
 /// it; this view just renders whatever `DiagnoseRunner` currently has.
 public struct DiagnosePanel: View {
     @ObservedObject public var runner: DiagnoseRunner
+    public let mountState: MountState?
 
     public init(runner: DiagnoseRunner) {
         self.runner = runner
+        self.mountState = nil
+    }
+
+    public init(runner: DiagnoseRunner, mountState: MountState?) {
+        self.runner = runner
+        self.mountState = mountState
     }
 
     public var body: some View {
         Group {
             if let report = runner.report {
                 VStack(alignment: .leading, spacing: 6) {
-                    ForEach(DiagnoseSummary.rows(for: report)) { row in
-                        Label("\(row.label): \(row.value)", systemImage: row.isHealthy ? "checkmark.circle" : "exclamationmark.circle")
-                            .foregroundStyle(row.isHealthy ? Color.primary : Color.orange)
+                    ForEach(DiagnoseSummary.rows(for: report, mountState: mountState)) { row in
+                        Label("\(row.label): \(row.value)", systemImage: iconName(for: row.status))
+                            .foregroundStyle(color(for: row.status))
                             .font(.caption)
+                            .help(row.explanation)
+                            .accessibilityHint(row.explanation)
                     }
                 }
                 .padding(10)
@@ -79,5 +151,23 @@ public struct DiagnosePanel: View {
             }
         }
         .padding(.top, 4)
+    }
+
+    private func iconName(for status: DiagnoseStatus) -> String {
+        switch status {
+        case .healthy: "checkmark.circle"
+        case .informational: "info.circle"
+        case .warning: "exclamationmark.circle"
+        case .unavailable: "questionmark.circle"
+        }
+    }
+
+    private func color(for status: DiagnoseStatus) -> Color {
+        switch status {
+        case .healthy: .primary
+        case .informational: .ntfsBlue
+        case .warning: .orange
+        case .unavailable: .secondary
+        }
     }
 }

--- a/gui/Views/PopoverContentView.swift
+++ b/gui/Views/PopoverContentView.swift
@@ -242,7 +242,7 @@ public struct PopoverContentView: View {
             }
 
             if showDiagnose {
-                DiagnosePanel(runner: diagnoseRunner)
+                DiagnosePanel(runner: diagnoseRunner, mountState: appState.state)
             }
 
             Divider()
@@ -445,4 +445,3 @@ struct FDAPromptView: View {
         .frame(width: 340)
     }
 }
-


### PR DESCRIPTION
## Summary

This PR makes the GUI diagnostic status reflect operational context instead of treating every stopped vmnet bridge as a fault.

While ntfsmac is idle, the private host-only bridge is expected to be down. The GUI now distinguishes that normal state from a bridge failure while a drive is mounted.

## Root cause

The diagnostic row model used a Boolean healthy/unhealthy value. That representation could not express an expected idle state, a transition, an actionable warning, and unavailable data separately. As a result, `bridge=down` was always rendered as a warning even though the CLI correctly kept the overall diagnostic result healthy while idle.

## Implementation

- Replace the binary diagnostic presentation with explicit healthy, informational, warning, and unavailable semantics.
- Keep the existing compatibility accessor for callers that still need the previous Boolean representation.
- Interpret the vmnet bridge using the known application mount state:
  - idle + bridge down: informational;
  - mount starting + bridge down: informational;
  - mounted + bridge down: warning;
  - bridge up: healthy.
- Keep unknown or malformed values neutral instead of presenting an unverified failure.
- Add concise help and accessibility context for diagnostic concepts.
- Update `GUI-PLAN.md` with the clarified diagnostic contract.

## Compatibility and scope

- Preserves the macOS 13.0 deployment target.
- Does not change the CLI diagnostic JSON format.
- Does not change mount, unmount, NFS, vmnet, pf, route, signing, packaging, or the SMJobBless/XPC privilege boundary.
- Does not add dependencies.

## Verification

Validated on commit `232cd0d6a1cb09fcfa8678b2655f83ef123cf936`, based directly on upstream `v1.1.020826` (`02678db`):

- `git diff --check upstream/main...HEAD` — passed;
- full Swift suite — 164 tests passed;
- fork `Package DMG` workflow — passed;
- integrated final-DMG no-drive diagnostic smoke test — passed.

The focused tests cover raw diagnostic values, idle/mounting/mounted bridge combinations, unknown and malformed reports, and compatibility behavior. A real mounted-drive bridge-failure check remains hardware-dependent and is not claimed here.
