### PR TITLE
feat(gui): make diagnostics dismissible

### DIFF
--- a/GUI-PLAN.md
+++ b/GUI-PLAN.md
@@ -84,6 +84,13 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 | `Retry` | Re-attempt last action |
 | `Diagnose` | Jump to diagnostics |
 
+### Diagnostic panel
+
+The diagnostic box includes a compact `Hide` action in its header. Hiding changes only panel
+visibility: it does not clear the last result, cancel an in-progress run, or touch mount/helper
+state. Selecting `Diagnose` again always reopens the box and starts one fresh diagnostic run.
+`Hide` remains keyboard-reachable and available for result, error, and running states.
+
 ### Preferences window
 
 | Control | Type | Default |

--- a/gui/Tests/DiagnoseRunnerTests.swift
+++ b/gui/Tests/DiagnoseRunnerTests.swift
@@ -95,3 +95,38 @@ private final class FakeRunner: PrivilegedCommandRunning {
     #expect(runner.errorMessage?.contains("NSCocoaErrorDomain") == false)
     #expect(runner.errorMessage == "ntfsmac isn't installed yet. If you just installed the helper, this can take a few seconds — try again, or use Preferences ▸ Reinstall privileged helper.")
 }
+
+@Test func diagnosticPresentationCoversHiddenRunningResultAndErrorPhases() {
+    let report = DiagnoseReport(healthy: true, missingBinaries: 0, quarantinedBinaries: 0, kernelPin: "match", bridge: "up")
+    var presentation = DiagnosePanelPresentation()
+
+    #expect(presentation.phase(report: report, errorMessage: "failure", isRunning: true) == .hidden)
+    presentation.show()
+    #expect(presentation.phase(report: nil, errorMessage: nil, isRunning: true) == .running)
+    #expect(presentation.phase(report: report, errorMessage: nil, isRunning: false) == .result)
+    #expect(presentation.phase(report: nil, errorMessage: "failure", isRunning: false) == .error)
+    presentation.hide()
+    #expect(presentation.phase(report: report, errorMessage: nil, isRunning: false) == .hidden)
+}
+
+@MainActor
+@Test func hidingKeepsDiagnosticDataAndReopeningRunsExactlyOnceAgain() async {
+    let fake = FakeRunner()
+    let runner = DiagnoseRunner(runner: fake, ntfsmacPath: "/fake/ntfsmac", fileExists: { _ in true })
+    var presentation = DiagnosePanelPresentation()
+
+    presentation.show()
+    await runner.run()
+    #expect(fake.calls.count == 1)
+    let firstReport = runner.report
+
+    presentation.hide()
+    #expect(!presentation.isVisible)
+    #expect(runner.report == firstReport)
+
+    presentation.show()
+    await runner.run()
+    #expect(presentation.isVisible)
+    #expect(fake.calls.count == 2)
+    #expect(runner.report == firstReport)
+}

--- a/gui/Views/DiagnosePanel.swift
+++ b/gui/Views/DiagnosePanel.swift
@@ -1,5 +1,33 @@
 import SwiftUI
 
+public enum DiagnosePanelPhase: Equatable, Sendable {
+    case hidden
+    case running
+    case result
+    case error
+    case empty
+}
+
+/// Visibility is independent from diagnostic data: hiding the panel must never clear a result,
+/// cancel work, or change helper/mount state. Keeping this as a small value type also makes every
+/// visibility transition testable without coupling tests to SwiftUI internals.
+public struct DiagnosePanelPresentation: Equatable, Sendable {
+    public private(set) var isVisible = false
+
+    public init() {}
+
+    public mutating func show() { isVisible = true }
+    public mutating func hide() { isVisible = false }
+
+    public func phase(report: DiagnoseReport?, errorMessage: String?, isRunning: Bool) -> DiagnosePanelPhase {
+        guard isVisible else { return .hidden }
+        if isRunning { return .running }
+        if report != nil { return .result }
+        if errorMessage != nil { return .error }
+        return .empty
+    }
+}
+
 /// Plain-language summary row (this unit's Do clause: "render a plain-language summary" — not
 /// a raw JSON/log dump).
 public struct DiagnoseSummaryRow: Equatable, Sendable, Identifiable {
@@ -47,37 +75,62 @@ public enum DiagnoseSummary {
 /// it; this view just renders whatever `DiagnoseRunner` currently has.
 public struct DiagnosePanel: View {
     @ObservedObject public var runner: DiagnoseRunner
+    public let onHide: (() -> Void)?
 
     public init(runner: DiagnoseRunner) {
         self.runner = runner
+        self.onHide = nil
+    }
+
+    public init(runner: DiagnoseRunner, onHide: @escaping () -> Void) {
+        self.runner = runner
+        self.onHide = onHide
     }
 
     public var body: some View {
-        Group {
-            if let report = runner.report {
-                VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 8) {
+            if let onHide {
+                HStack(spacing: 8) {
+                    Text("Diagnostics")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Button("Hide", action: onHide)
+                        .buttonStyle(.plain)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Hide diagnostics")
+                        .help("Hide the diagnostic panel")
+                }
+            }
+
+            Group {
+                if let report = runner.report {
                     ForEach(DiagnoseSummary.rows(for: report)) { row in
                         Label("\(row.label): \(row.value)", systemImage: row.isHealthy ? "checkmark.circle" : "exclamationmark.circle")
                             .foregroundStyle(row.isHealthy ? Color.primary : Color.orange)
                             .font(.caption)
                     }
+                } else if let errorMessage = runner.errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(Color.ntfsRed.opacity(0.95))
+                } else if runner.isRunning {
+                    ProgressView().frame(maxWidth: .infinity)
                 }
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(Color.secondary.opacity(0.08)))
-                .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(Color.secondary.opacity(0.12)))
-            } else if let errorMessage = runner.errorMessage {
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundStyle(Color.ntfsRed.opacity(0.95))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(10)
-                    .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(Color.ntfsRed.opacity(0.09)))
-                    .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(Color.ntfsRed.opacity(0.2)))
-            } else if runner.isRunning {
-                ProgressView().frame(maxWidth: .infinity)
             }
         }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(panelBackgroundColor))
+        .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(panelBorderColor))
         .padding(.top, 4)
+    }
+
+    private var panelBackgroundColor: Color {
+        runner.errorMessage == nil ? Color.secondary.opacity(0.08) : Color.ntfsRed.opacity(0.09)
+    }
+
+    private var panelBorderColor: Color {
+        runner.errorMessage == nil ? Color.secondary.opacity(0.12) : Color.ntfsRed.opacity(0.2)
     }
 }

--- a/gui/Views/FirstRunView.swift
+++ b/gui/Views/FirstRunView.swift
@@ -16,7 +16,7 @@ public struct FirstRunView: View {
     public let onQuit: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
-    @State private var showDiagnose = false
+    @State private var diagnosePresentation = DiagnosePanelPresentation()
 
     public init(installer: HelperInstaller, diagnoseRunner: DiagnoseRunner, onQuit: @escaping () -> Void) {
         self.installer = installer
@@ -52,7 +52,7 @@ public struct FirstRunView: View {
                 .buttonStyle(.glassPrimary())
 
                 Button {
-                    showDiagnose = true
+                    diagnosePresentation.show()
                     Task { await diagnoseRunner.run() }
                 } label: {
                     HStack(spacing: 5) {
@@ -65,8 +65,10 @@ public struct FirstRunView: View {
                 .disabled(diagnoseRunner.isRunning)
             }
 
-            if showDiagnose {
-                DiagnosePanel(runner: diagnoseRunner)
+            if diagnosePresentation.isVisible {
+                DiagnosePanel(runner: diagnoseRunner) {
+                    diagnosePresentation.hide()
+                }
             }
 
             Divider()

--- a/gui/Views/PopoverContentView.swift
+++ b/gui/Views/PopoverContentView.swift
@@ -70,7 +70,7 @@ public struct PopoverContentView: View {
     public let helperClient: HelperClient
 
     @Environment(\.colorScheme) private var colorScheme
-    @State private var showDiagnose = false
+    @State private var diagnosePresentation = DiagnosePanelPresentation()
     @State private var showFDAPrompt = false
 
     public init(
@@ -241,8 +241,10 @@ public struct PopoverContentView: View {
                 Text(errorMessage).font(.caption).foregroundStyle(Color.ntfsRed)
             }
 
-            if showDiagnose {
-                DiagnosePanel(runner: diagnoseRunner)
+            if diagnosePresentation.isVisible {
+                DiagnosePanel(runner: diagnoseRunner) {
+                    diagnosePresentation.hide()
+                }
             }
 
             Divider()
@@ -353,7 +355,7 @@ public struct PopoverContentView: View {
             .buttonStyle(.glassIcon(colorScheme: colorScheme))
 
             Button {
-                showDiagnose = true
+                diagnosePresentation.show()
                 Task { await diagnoseRunner.run() }
             } label: {
                 HStack(spacing: 5) {
@@ -445,4 +447,3 @@ struct FDAPromptView: View {
         .frame(width: 340)
     }
 }
-


### PR DESCRIPTION
## Summary

This PR adds an explicit, keyboard-reachable `Hide` action to the diagnostic panel so users can return to the normal compact popover without restarting or rebuilding application state.

## Root cause

Selecting `Diagnose` made the diagnostic panel visible, but the panel had no control that could return its visibility state to false. Once opened, the result remained in the popover for the lifetime of that view state.

## Implementation

- Add a compact `Hide` action to diagnostic running, result, and error states.
- Keep panel visibility independent from the diagnostic data and mount/helper state.
- Preserve the previous diagnostic result when the panel is hidden.
- Make a later `Diagnose` action reopen the panel and start exactly one fresh run.
- Apply the same presentation behavior to normal and first-run content.
- Keep the action keyboard reachable with an explicit accessibility label.
- Update `GUI-PLAN.md` with the diagnostic-panel visibility contract.

## Compatibility and scope

- Preserves the current popover width and macOS 13.0 deployment target.
- Does not cancel a running diagnostic or start background work when hiding the panel.
- Does not change mount, unmount, NFS, vmnet, pf, route, signing, packaging, or the SMJobBless/XPC privilege boundary.
- Does not add dependencies.

## Verification

Validated on commit `149dd8d7125eb8c01794093beae14608a2b2f0e1`, based directly on upstream `v1.1.020826` (`02678db`):

- `git diff --check upstream/main...HEAD` — passed;
- full Swift suite — 162 tests passed;
- fork `Package DMG` workflow — passed;
- integrated final-DMG Diagnose → Hide → Diagnose smoke test — passed.

The focused tests cover hidden, running, result, and error transitions, preservation of diagnostic data, and exactly one fresh run when the panel is reopened.

## Review order

This branch is independently based on upstream `main`. It follows the diagnostic-semantics PR in the planned review order and may need a small rebase if that PR lands first because both changes intentionally touch the diagnostic panel.
