### PR TITLE
feat(gui): keep settings and uninstall inside the popover

### DIFF
--- a/GUI-PLAN.md
+++ b/GUI-PLAN.md
@@ -13,7 +13,8 @@
 
 ## App shape
 
-Menu-bar agent → click icon → popover. No windows except Preferences and the first-run helper prompt.
+Menu-bar agent → click icon → popover. Settings is a page inside that same popover; the only
+separate system UI is the first-run helper authorization prompt.
 
 ### Menu-bar icon states
 
@@ -57,7 +58,7 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 | Drive row `[Mount]` | Mount that drive r/w via XPC helper | A compatible drive is detected |
 | Refresh (↻) | Re-scan drives now | Always |
 | `Diagnose` | Run CLI diagnostic, show summary | Always |
-| ⚙ (gear) | Open Preferences | Always |
+| ⚙ (gear) | Navigate to Settings in the popover | Always |
 | `Quit` | Exit app, tear down network state | Always |
 
 ### Popover — mounted
@@ -84,7 +85,12 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 | `Retry` | Re-attempt last action |
 | `Diagnose` | Jump to diagnostics |
 
-### Preferences window
+### Settings page
+
+The gear replaces the main popover content with Settings. A keyboard-reachable `Back` action
+returns to the previous application content. Normal, first-run, and CLI-repair screens all use the
+same route and the same long-lived Settings/helper objects; navigation does not open an `NSWindow`
+or recreate in-flight state.
 
 | Control | Type | Default |
 |---------|------|---------|

--- a/GUI-PLAN.md
+++ b/GUI-PLAN.md
@@ -101,6 +101,12 @@ small secondary text; it is informative and never competes visually with the `Se
 | Show speed in menu bar | Toggle | Off |
 | Reinstall privileged helper | Button | — |
 
+The destructive uninstall confirmation is rendered inside the Settings page so selecting it does
+not dismiss the transient menu-bar popover before the operation starts. Cancel consumes no action;
+confirm can start the flow only once, and the control remains disabled while removal is active or
+after it completes. The helper XPC connection is created lazily on the first privileged request,
+not merely because the app launched.
+
 ---
 
 ## Control → privilege boundary (non-negotiable)

--- a/GUI-PLAN.md
+++ b/GUI-PLAN.md
@@ -90,7 +90,8 @@ separate system UI is the first-run helper authorization prompt.
 The gear replaces the main popover content with Settings. A keyboard-reachable `Back` action
 returns to the previous application content. Normal, first-run, and CLI-repair screens all use the
 same route and the same long-lived Settings/helper objects; navigation does not open an `NSWindow`
-or recreate in-flight state.
+or recreate in-flight state. The title includes the app release/build directly underneath in
+small secondary text; it is informative and never competes visually with the `Settings` heading.
 
 | Control | Type | Default |
 |---------|------|---------|

--- a/Package.swift
+++ b/Package.swift
@@ -73,7 +73,7 @@ let package = Package(
                 "Actions/DiagnoseRunner.swift", "Views/DiagnosePanel.swift",
                 "FirstRun/HelperInstaller.swift", "Views/FirstRunView.swift",
                 "FirstRun/HelperUninstaller.swift", "FirstRun/CLIInstallChecker.swift", "Views/CLIMissingView.swift",
-                "Preferences/Settings.swift", "Preferences/PreferencesView.swift",
+                "Preferences/ProductVersion.swift", "Preferences/Settings.swift", "Preferences/PreferencesView.swift",
                 "Style/Colors.swift", "Style/GlassTheme.swift", "Style/Icons.swift", "Style/PillButtons.swift",
                 "State/PopoverNavigation.swift",
                 "Views/PopoverContentView.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,7 @@ let package = Package(
                 "FirstRun/HelperUninstaller.swift", "FirstRun/CLIInstallChecker.swift", "Views/CLIMissingView.swift",
                 "Preferences/Settings.swift", "Preferences/PreferencesView.swift",
                 "Style/Colors.swift", "Style/GlassTheme.swift", "Style/Icons.swift", "Style/PillButtons.swift",
+                "State/PopoverNavigation.swift",
                 "Views/PopoverContentView.swift",
             ]
         ),

--- a/docs/dev/GUI-PLAN.md
+++ b/docs/dev/GUI-PLAN.md
@@ -13,7 +13,8 @@
 
 ## App shape
 
-Menu-bar agent → click icon → popover. No windows except Preferences and the first-run helper prompt.
+Menu-bar agent → click icon → popover. Settings is a page inside that same popover; the only
+separate system UI is the first-run helper authorization prompt.
 
 ### Menu-bar icon states
 
@@ -57,7 +58,7 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 | Drive row `[Mount]` | Mount that drive r/w via XPC helper | A compatible drive is detected |
 | Refresh (↻) | Re-scan drives now | Always |
 | `Diagnose` | Run CLI diagnostic, show summary | Always |
-| ⚙ (gear) | Open Preferences | Always |
+| ⚙ (gear) | Navigate to Settings in the popover | Always |
 | `Quit` | Exit app, tear down network state | Always |
 
 ### Popover — mounted
@@ -84,7 +85,12 @@ Menu-bar agent → click icon → popover. No windows except Preferences and the
 | `Retry` | Re-attempt last action |
 | `Diagnose` | Jump to diagnostics |
 
-### Preferences window
+### Settings page
+
+The gear replaces the main popover content with Settings. A keyboard-reachable `Back` action
+returns to the previous application content. Normal, first-run, and CLI-repair screens all use the
+same route and the same long-lived Settings/helper objects; navigation does not open an `NSWindow`
+or recreate in-flight state.
 
 | Control | Type | Default |
 |---------|------|---------|

--- a/docs/dev/GUI-PLAN.md
+++ b/docs/dev/GUI-PLAN.md
@@ -101,6 +101,12 @@ small secondary text; it is informative and never competes visually with the `Se
 | Show speed in menu bar | Toggle | Off |
 | Reinstall privileged helper | Button | — |
 
+The destructive uninstall confirmation is rendered inside the Settings page so selecting it does
+not dismiss the transient menu-bar popover before the operation starts. Cancel consumes no action;
+confirm can start the flow only once, and the control remains disabled while removal is active or
+after it completes. The helper XPC connection is created lazily on the first privileged request,
+not merely because the app launched.
+
 ---
 
 ## Control → privilege boundary (non-negotiable)

--- a/docs/dev/GUI-PLAN.md
+++ b/docs/dev/GUI-PLAN.md
@@ -90,7 +90,8 @@ separate system UI is the first-run helper authorization prompt.
 The gear replaces the main popover content with Settings. A keyboard-reachable `Back` action
 returns to the previous application content. Normal, first-run, and CLI-repair screens all use the
 same route and the same long-lived Settings/helper objects; navigation does not open an `NSWindow`
-or recreate in-flight state.
+or recreate in-flight state. The title includes the app release/build directly underneath in
+small secondary text; it is informative and never competes visually with the `Settings` heading.
 
 | Control | Type | Default |
 |---------|------|---------|

--- a/docs/dev/PLAN.md
+++ b/docs/dev/PLAN.md
@@ -572,7 +572,8 @@ sha256-checked downloads verified by checksum assertions, not unit tests).
   (button → `3-first-run-install`); persist via `@AppStorage`/UserDefaults.
 - **Don't:** add controls beyond the GUI-PLAN table.
 - **Acceptance:** `SettingsTests` assert defaults + persistence round-trip; `ProductVersionTests`
-  assert bundle metadata formatting.
+  assert bundle metadata formatting; `PreferencesUninstallTests` assert inline confirmation and
+  one-shot destructive action; `HelperClientTests` assert no XPC connection is created at launch.
 
 #### `3-liquid-glass`  ← styling pass, last, solo
 - **Deps:** all Phase 3 feature units · **Tier:** medium

--- a/docs/dev/PLAN.md
+++ b/docs/dev/PLAN.md
@@ -566,11 +566,13 @@ sha256-checked downloads verified by checksum assertions, not unit tests).
 #### `3-preferences`
 - **Deps:** `3-menubar-shell`, `3-first-run-install` · **Tier:** medium
 - **Files:** `gui/Preferences/PreferencesView.swift`, `gui/Preferences/Settings.swift`, `gui/Tests/SettingsTests.swift`
-- **Do:** controls with GUI-PLAN defaults — Launch at login (off), Default mount mode (Read-write),
+- **Do:** show the release/build below the Settings title as small secondary text; controls with
+  GUI-PLAN defaults — Launch at login (off), Default mount mode (Read-write),
   Default mount point (`/Volumes/<label>`), Show speed in menu bar (off), Reinstall privileged helper
   (button → `3-first-run-install`); persist via `@AppStorage`/UserDefaults.
 - **Don't:** add controls beyond the GUI-PLAN table.
-- **Acceptance:** `SettingsTests` assert defaults + persistence round-trip.
+- **Acceptance:** `SettingsTests` assert defaults + persistence round-trip; `ProductVersionTests`
+  assert bundle metadata formatting.
 
 #### `3-liquid-glass`  ← styling pass, last, solo
 - **Deps:** all Phase 3 feature units · **Tier:** medium

--- a/docs/dev/SHARED_TASK_NOTES.md
+++ b/docs/dev/SHARED_TASK_NOTES.md
@@ -715,6 +715,13 @@ still-open VM-boot gate and an end-to-end "connect a real NTFS drive" walkthroug
   Anything not yet built that still needed a literal-CSS lookup from the prototype (remaining
   `3-liquid-glass` polish, any un-walked states in `docs/dev/UITest.md`) now has to go off the
   running app + the maintainer's direction — flag if a specific value can't be recovered that way.
+- **In-popover Settings follow-up (2026-08-03)** — the gear now navigates within the existing
+  `MenuBarExtra` instead of opening a second `NSWindow`. Normal, first-run, and CLI-repair screens
+  share one `PopoverNavigation` route; Back restores the app content, while the app-owned
+  `Settings`, `HelperInstaller`, and `HelperUninstaller` instances survive navigation. The
+  runtime `PreferencesOpener` window implementation was removed; deprecated source-compatible
+  adapters remain for downstream callers, but the app does not use them. No mount, helper
+  privilege, signing, or deployment-target behavior changed.
 
 ## DECISIONS
 

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -274,8 +274,9 @@ The menu-bar icon itself uses a placeholder SF Symbol for now — see "app icon"
 5. Click `Diagnose` in the footer, then the `Diagnose` button inside the panel that appears —
    should match Part A's `diagnose --json` output in plain language.
 6. Click `Unmount` — icon returns to grey/idle, drive drops off the mounted row.
-7. Click the gear icon — Settings replaces the popover content. Toggle settings, use Back, reopen
-   Settings — confirm they persisted (backed by `UserDefaults`, should survive
+7. Click the gear icon — Settings replaces the popover content. Confirm the current app
+   release/build appears directly below `Settings` as small secondary text. Toggle settings, use
+   Back, reopen Settings — confirm they persisted (backed by `UserDefaults`, should survive
    without even restarting the app).
 8. Click `Quit` — app should exit; `mount | grep nfs` back in Terminal should show nothing
    ntfsmac-related left mounted.

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -278,7 +278,11 @@ The menu-bar icon itself uses a placeholder SF Symbol for now — see "app icon"
    release/build appears directly below `Settings` as small secondary text. Toggle settings, use
    Back, reopen Settings — confirm they persisted (backed by `UserDefaults`, should survive
    without even restarting the app).
-8. Click `Quit` — app should exit; `mount | grep nfs` back in Terminal should show nothing
+8. As the final cleanup check, click `Uninstall…` in Settings. Confirm the destructive prompt stays
+   inside the popover; cancel once, reopen it, then confirm. A freshly installed helper must uninstall
+   on the first confirmed attempt, the UI must reach `Uninstalled`, and the uninstall action must
+   remain disabled afterward.
+9. Click `Quit` — app should exit; `mount | grep nfs` back in Terminal should show nothing
    ntfsmac-related left mounted.
 
 ### Force a dirty-journal (read-only) test, optional

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -23,10 +23,9 @@ wires them in — reviewed (`ecc:swift-reviewer`, approve), 77/77 tests still gr
   indicators (currently `.unknown`/`.unknown` — Phase 1 pf/route hardening state isn't surfaced
   by `diagnose.sh` yet, a separate, already-documented gap, not new here), Open in Finder,
   Diagnose panel, Refresh, and Quit (which tears down pf/route state via the helper first).
-- A `Settings { PreferencesView(...) }` scene is now registered — the gear button in the popover
-  footer opens it via `NSApp.sendAction(Selector(("showSettingsWindow:")), ...)` (the standard
-  macOS-13-compatible way to open a `Settings` scene; `@Environment(\.openSettings)` needs
-  macOS 14+, which this project's floor doesn't allow).
+- The gear button replaces the current popover content with the in-popover Settings page. `Back`
+  returns to the previous app content; no separate Preferences `NSWindow` or private selector is
+  used.
 
 **Known, deliberately out-of-scope limitations that remain** (don't report these as new bugs):
 `Settings.defaultMountMode`/`defaultMountPoint` are stored but not yet threaded into the actual
@@ -67,7 +66,7 @@ been through every state at least once:
   unmount → (if you can trigger a dirty journal — see below) mounted read-only (yellow, banner
   visible) → unplug the helper's launchd job or rename a vendor binary to force an error state
   (red) — real repro, not required, only if you want full color coverage.
-- **Preferences window**: open via the gear button, compare against the Preferences screen
+- **Settings page**: open via the gear button, compare against the Settings screen, then use Back
   (light isn't separately specified — not a gap, only one appearance is defined for this screen).
 - Known approximation, not a bug: the popover's drop shadow collapses the original two-layer
   box-shadow + inset rim-light into one `.shadow()` call (SwiftUI has no multi-shadow primitive)
@@ -275,8 +274,8 @@ The menu-bar icon itself uses a placeholder SF Symbol for now — see "app icon"
 5. Click `Diagnose` in the footer, then the `Diagnose` button inside the panel that appears —
    should match Part A's `diagnose --json` output in plain language.
 6. Click `Unmount` — icon returns to grey/idle, drive drops off the mounted row.
-7. Click the gear icon — Preferences window opens (compare against Gap 2's screen). Toggle
-   settings, close, reopen — confirm they persisted (backed by `UserDefaults`, should survive
+7. Click the gear icon — Settings replaces the popover content. Toggle settings, use Back, reopen
+   Settings — confirm they persisted (backed by `UserDefaults`, should survive
    without even restarting the app).
 8. Click `Quit` — app should exit; `mount | grep nfs` back in Terminal should show nothing
    ntfsmac-related left mounted.

--- a/docs/dev/UITest.md
+++ b/docs/dev/UITest.md
@@ -24,6 +24,12 @@ via live testing that unit tests couldn't catch (no real XPC/process exercise in
    opens with all 5 GUI-PLAN.md controls. The `Settings { }` scene declaration was removed
    (dead code — it never worked).
 
+   **Superseded 2026-08-03:** Settings now replaces the content inside the existing menu-bar
+   popover and provides a Back action. The temporary `PreferencesOpener`/`NSWindow` runtime
+   workaround described above was removed; deprecated source-compatible adapters remain, but
+   the app no longer uses them to create a window. The same app-owned Settings/helper objects
+   remain in use.
+
 3. **SF Symbols swap** — all custom `Canvas`-drawn icons (`Icons.swift`) replaced with SF Symbols
    (`gearshape.fill`, `stethoscope`, `eject.fill`, `exclamationmark.triangle.fill`, etc.), except
    `DriveGlyph.menuBar` — kept as the literal comp transcription per explicit instruction ("keep
@@ -121,7 +127,7 @@ is installed"), built a real, tested pipeline:
 | 3 | CLI missing / "Setup incomplete" | Yes | Live-verified for real this session (triggered naturally after a real `removeDependencies()` uninstall) — red warning icon, plain-language copy, "Check Again" button. Correct fallback. |
 | 4 | Idle, no drives / with drive | Yes | Icons, Mount, Diagnose, gear, Quit all confirmed real and working |
 | 5–9 | Mounting / mounted (rw/ro/dirty) / error | Yes | Unblocked this session via the `DemoScaffold` mock-`MountState` harness (`NTFSMAC_UI_DEMO=clean\|dirty\|error`). All 5 states walked live: mounting (blue pulsing), mounted read-write (green), mounted read-only-dirty (yellow, unclean-journal banner, "Mount read/write anyway…"), error (red, plain-language message). Menu-bar icon color confirmed correct for every state (see bug fix below). |
-| 10 | Preferences window | Yes | Real `NSWindow`, 4 controls (not GUI-PLAN's 5 — "Default mount mode"/"Default mount point" aren't implemented as separate controls in the current build). Reinstall and Uninstall buttons both live-tested for real (see below), not just unit-tested. |
+| 10 | In-popover Settings page | Yes | Packaged app verified live on 2026-08-03: gear replaced the popover content with Settings; Back restored the drive list; Launch at login, Reinstall…, and Uninstall… controls were visible; no separate window opened. |
 | 11 | Diagnose panel | Yes | Single button, styled output card |
 
 Light/dark appearance toggle still not walked for any state — deferred, not done this session (budget).

--- a/gui/Actions/PreferencesOpener.swift
+++ b/gui/Actions/PreferencesOpener.swift
@@ -1,74 +1,21 @@
-import AppKit
 import SwiftUI
-import os.log
 
-private let preferencesLog = Logger(subsystem: "com.khr898.ntfsmac", category: "PreferencesOpener")
+extension Notification.Name {
+    static let ntfsmacOpenSettings = Notification.Name("com.khr898.ntfsmac.open-settings")
+}
 
-/// Opens the Preferences window (GUI-PLAN.md "Preferences window" — gear icon in every screen's
-/// footer). Originally routed through SwiftUI's `Settings` scene via
-/// `NSApp.sendAction(Selector(("showSettingsWindow:")), ...)` — a private, reverse-engineered
-/// selector, not documented API. Empirically confirmed dead on this box (macOS 26.5): no
-/// `activate()`/dispatch-timing combination ever made the Settings window appear. The
-/// `@Environment(\.openSettings)` replacement Apple does document requires macOS 14 (this
-/// project's floor is 13.0 — `Package.swift`), so isn't usable unconditionally either. Showing a
-/// plain `NSWindow` directly sidesteps both: no private API, no version gate, no scene-action
-/// routing to race.
+/// Source-compatible adapter for callers of the former Preferences-window API. It no longer
+/// creates or owns an NSWindow: `open()` requests navigation to the in-popover Settings page.
 @MainActor
 public enum PreferencesOpener {
-    private static var window: NSWindow?
-    private static var makeContent: (() -> AnyView)?
-
-    /// Called once from `NtfsmacApp.init` with the same environment objects the old `Settings`
-    /// scene closure captured — `open()` itself takes no parameters so all 3 call sites
-    /// (`PopoverContentView`, `FirstRunView`, `CLIMissingView`) stay a single no-arg tap target.
+    @available(*, deprecated, message: "Settings content is owned by PopoverContentView")
     public static func configure(content: @escaping () -> AnyView) {
-        makeContent = content
+        // Retained only for source compatibility. The popover already owns the same long-lived
+        // Settings/helper instances, so retaining a second content factory would be misleading.
     }
 
+    @available(*, deprecated, message: "Use PopoverNavigation.showSettings()")
     public static func open() {
-        let beforeActivate = Date()
-        NSApp.activate(ignoringOtherApps: true)
-        logElapsed("NSApp.activate", since: beforeActivate)
-        if let window {
-            window.makeKeyAndOrderFront(nil)
-            return
-        }
-        guard let makeContent else { return }
-
-        // Diagnostic only, temporary: times the first-open cold-start path to localize the
-        // reported ~5s lag. Read via `log show --predicate 'category == "PreferencesOpener"'`.
-        let openStart = Date()
-
-        let beforeContent = Date()
-        let content = makeContent()
-        logElapsed("makeContent()", since: beforeContent)
-
-        let beforeHosting = Date()
-        let hosting = NSHostingController(rootView: content)
-        logElapsed("NSHostingController.init", since: beforeHosting)
-
-        let beforeWindow = Date()
-        let newWindow = NSWindow(contentViewController: hosting)
-        logElapsed("NSWindow.init", since: beforeWindow)
-
-        newWindow.title = "ntfsmac Preferences"
-        newWindow.styleMask = [.titled, .closable]
-        // `LSUIElement` apps have no real main window for Preferences to be a child of. `.floating`
-        // alone wasn't enough — reported still appearing behind the popover panel, confirmed live:
-        // `MenuBarExtra(.window)`'s own panel renders at `.popUpMenu` level (101), well above
-        // `.floating` (3). One level above that guarantees Preferences always draws in front of it.
-        newWindow.level = NSWindow.Level(rawValue: NSWindow.Level.popUpMenu.rawValue + 1)
-        newWindow.center()
-        window = newWindow
-
-        let beforeFront = Date()
-        newWindow.makeKeyAndOrderFront(nil)
-        logElapsed("makeKeyAndOrderFront", since: beforeFront)
-        logElapsed("open() total (first call)", since: openStart)
-    }
-
-    private static func logElapsed(_ label: String, since start: Date) {
-        let ms = Date().timeIntervalSince(start) * 1000
-        preferencesLog.notice("\(label, privacy: .public): \(ms, privacy: .public)ms")
+        NotificationCenter.default.post(name: .ntfsmacOpenSettings, object: nil)
     }
 }

--- a/gui/App/NtfsmacApp.swift
+++ b/gui/App/NtfsmacApp.swift
@@ -16,6 +16,7 @@ struct NtfsmacApp: App {
     @StateObject private var helperUninstaller: HelperUninstaller
     @StateObject private var cliInstallChecker: CLIInstallChecker
     @StateObject private var settings = Settings()
+    @StateObject private var navigation = PopoverNavigation()
 
     private let finderOpener = FinderOpener()
     private let helperClient = HelperClient()
@@ -64,10 +65,6 @@ struct NtfsmacApp: App {
         })
         _helperUninstaller = StateObject(wrappedValue: helperUninstaller)
 
-        let settings = self.settings
-        PreferencesOpener.configure {
-            AnyView(PreferencesView(settings: settings, installer: helperInstaller, uninstaller: helperUninstaller))
-        }
     }
 
     var body: some Scene {
@@ -80,11 +77,13 @@ struct NtfsmacApp: App {
                 remountController: remountController,
                 diagnoseRunner: diagnoseRunner,
                 helperInstaller: helperInstaller,
+                helperUninstaller: helperUninstaller,
                 cliInstallChecker: cliInstallChecker,
                 cliAutoStager: cliAutoStager,
                 settings: settings,
                 finderOpener: finderOpener,
-                helperClient: helperClient
+                helperClient: helperClient,
+                navigation: navigation
             )
             .popoverGlassBackground()
         } label: {

--- a/gui/Helper/HelperClient.swift
+++ b/gui/Helper/HelperClient.swift
@@ -21,27 +21,37 @@ public enum HelperClientError: Error {
 /// without an `@unchecked Sendable` escape hatch.
 @MainActor
 public final class HelperClient: Sendable {
-    // `nonisolated(unsafe)`: same documented exception as before (`invalidate()` is thread-safe
-    // per Apple's docs); all access now goes through `currentConnection()`, guarded by
-    // `connectionLock`.
+    // `nonisolated(unsafe)`: all access goes through `currentConnection()` or the invalidation
+    // handler, both guarded by `connectionLock`.
     //
-    // Self-healing: an invalidated NSXPCConnection never reconnects on its own — a connection that
-    // dies right after a fresh SMJobBless (daemon not listening yet) used to stay dead for the
-    // rest of the process, reading as "can't talk to helper until restart." `currentConnection()`
-    // rebuilds it on the next call instead.
-    private nonisolated(unsafe) var connection: NSXPCConnection
+    // The connection is intentionally lazy. Creating/resuming it in `init` races first-run
+    // SMJobBless: the app constructs its clients before the helper exists, leaving their first
+    // real request attached to a failed bootstrap connection. The user then sees "couldn't
+    // communicate with helper" immediately after authorizing a successful install. Creating it
+    // at the first privileged request removes that race; an invalidated connection is still
+    // rebuilt on the following call.
+    private nonisolated(unsafe) var connection: NSXPCConnection?
     private let connectionLock = NSLock()
     private let machServiceName: String
-    private nonisolated(unsafe) var needsReconnect = false
+    private let connectionFactory: @Sendable (String) -> NSXPCConnection
 
     public init(machServiceName: String = helperMachServiceName) {
         self.machServiceName = machServiceName
-        self.connection = Self.makeConnection(machServiceName: machServiceName)
-        wireInvalidationHandler(on: connection)
+        self.connectionFactory = Self.makeConnection(machServiceName:)
+        self.connection = nil
+    }
+
+    init(
+        machServiceName: String,
+        connectionFactory: @escaping @Sendable (String) -> NSXPCConnection
+    ) {
+        self.machServiceName = machServiceName
+        self.connectionFactory = connectionFactory
+        self.connection = nil
     }
 
     deinit {
-        connection.invalidate()
+        connection?.invalidate()
     }
 
     private nonisolated static func makeConnection(machServiceName: String) -> NSXPCConnection {
@@ -51,29 +61,33 @@ public final class HelperClient: Sendable {
         return connection
     }
 
-    // Runs on XPC's own queue, not the main actor (same as `call()`/`version()` below). Only flips
-    // a flag; `currentConnection()` does the actual rebuild lazily on the next call.
+    // Runs on XPC's own queue, not the main actor (same as `call()`/`version()` below). Clear only
+    // the connection that actually invalidated: a delayed callback from an old connection must
+    // not discard a newer replacement.
     private nonisolated func wireInvalidationHandler(on connection: NSXPCConnection) {
-        connection.invalidationHandler = { [weak self] in
-            guard let self else { return }
+        connection.invalidationHandler = { [weak self, weak connection] in
+            guard let self, let connection else { return }
             helperClientLog.notice("XPC connection invalidated — will rebuild on next call")
             self.connectionLock.lock()
-            self.needsReconnect = true
+            if self.connection === connection {
+                self.connection = nil
+            }
             self.connectionLock.unlock()
         }
     }
 
-    // `connectionLock`-guarded so the invalidation callback above and a `call()`/`version()`
-    // caller can't race over which connection is "current."
+    // `connectionLock`-guarded so construction and invalidation cannot race over which connection
+    // is current. Nothing is created until the first actual helper request.
     private nonisolated func currentConnection() -> NSXPCConnection {
         connectionLock.lock()
         defer { connectionLock.unlock() }
-        if needsReconnect {
-            connection = Self.makeConnection(machServiceName: machServiceName)
-            wireInvalidationHandler(on: connection)
-            needsReconnect = false
+        if let connection {
+            return connection
         }
-        return connection
+        let newConnection = connectionFactory(machServiceName)
+        connection = newConnection
+        wireInvalidationHandler(on: newConnection)
+        return newConnection
     }
 
     // `nonisolated`: NSXPCConnection invokes both this and the error handler below from its own

--- a/gui/Preferences/PreferencesView.swift
+++ b/gui/Preferences/PreferencesView.swift
@@ -29,6 +29,7 @@ public struct PreferencesView: View {
     @ObservedObject public var installer: HelperInstaller
     @ObservedObject public var uninstaller: HelperUninstaller
     public let onBack: (() -> Void)?
+    public let productVersion: ProductVersion
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var uninstallConfirmation: UninstallConfirmationPresentation
@@ -44,6 +45,24 @@ public struct PreferencesView: View {
             installer: installer,
             uninstaller: uninstaller,
             onBack: onBack,
+            productVersion: .current(),
+            uninstallConfirmation: .init()
+        )
+    }
+
+    public init(
+        settings: Settings,
+        installer: HelperInstaller,
+        uninstaller: HelperUninstaller,
+        onBack: (() -> Void)?,
+        productVersion: ProductVersion
+    ) {
+        self.init(
+            settings: settings,
+            installer: installer,
+            uninstaller: uninstaller,
+            onBack: onBack,
+            productVersion: productVersion,
             uninstallConfirmation: .init()
         )
     }
@@ -53,12 +72,14 @@ public struct PreferencesView: View {
         installer: HelperInstaller,
         uninstaller: HelperUninstaller,
         onBack: (() -> Void)?,
+        productVersion: ProductVersion,
         uninstallConfirmation: UninstallConfirmationPresentation
     ) {
         self.settings = settings
         self.installer = installer
         self.uninstaller = uninstaller
         self.onBack = onBack
+        self.productVersion = productVersion
         _uninstallConfirmation = State(initialValue: uninstallConfirmation)
     }
 
@@ -85,7 +106,14 @@ public struct PreferencesView: View {
                 }
 
                 Spacer()
-                Text("Settings").font(.system(size: 13, weight: .semibold))
+                VStack(spacing: 1) {
+                    Text("Settings")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(productVersion.settingsText)
+                        .font(.system(size: 9, weight: .regular))
+                        .foregroundStyle(.secondary.opacity(0.72))
+                        .accessibilityLabel("ntfsmac \(productVersion.settingsText)")
+                }
                 Spacer()
 
                 // Balance the Back pill so the title stays centered without adding a second

--- a/gui/Preferences/PreferencesView.swift
+++ b/gui/Preferences/PreferencesView.swift
@@ -1,24 +1,62 @@
 import SwiftUI
-import AppKit
 
-/// GUI-PLAN.md "Preferences window" table, exactly these five controls (Don't clause: nothing
-/// beyond this table). "Reinstall privileged helper" reuses `HelperInstaller.install()` directly
-/// — the same path `3-first-run-install` built for first-run, per that unit's own Do clause.
+/// GUI-PLAN.md "Settings page" table, using the same controls and application-owned state as the
+/// former Preferences window. "Reinstall privileged helper" reuses `HelperInstaller.install()`
+/// directly — the same path `3-first-run-install` built for first-run, per that unit's Do clause.
 public struct PreferencesView: View {
     @ObservedObject public var settings: Settings
     @ObservedObject public var installer: HelperInstaller
     @ObservedObject public var uninstaller: HelperUninstaller
+    public let onBack: (() -> Void)?
 
+    @Environment(\.colorScheme) private var colorScheme
     @State private var isConfirmingUninstall = false
 
-    public init(settings: Settings, installer: HelperInstaller, uninstaller: HelperUninstaller) {
+    public init(
+        settings: Settings,
+        installer: HelperInstaller,
+        uninstaller: HelperUninstaller,
+        onBack: (() -> Void)?
+    ) {
         self.settings = settings
         self.installer = installer
         self.uninstaller = uninstaller
+        self.onBack = onBack
+    }
+
+    /// Source-compatible initializer for existing embeddings. The production app always supplies
+    /// `onBack` and presents this view inside the menu-bar popover.
+    public init(settings: Settings, installer: HelperInstaller, uninstaller: HelperUninstaller) {
+        self.init(settings: settings, installer: installer, uninstaller: uninstaller, onBack: nil)
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                if let onBack {
+                    Button(action: onBack) {
+                        HStack(spacing: 5) {
+                            Image(systemName: "chevron.left")
+                            Text("Back")
+                        }
+                    }
+                    .buttonStyle(.glassNeutral(colorScheme: colorScheme))
+                    .accessibilityLabel("Back to drives")
+                } else {
+                    Color.clear.frame(width: 57, height: 1)
+                }
+
+                Spacer()
+                Text("Settings").font(.system(size: 13, weight: .semibold))
+                Spacer()
+
+                // Balance the Back pill so the title stays centered without adding a second
+                // action or a hidden duplicate Settings control.
+                Color.clear.frame(width: 57, height: 1)
+            }
+
+            Divider()
+
             row("Launch at login", "Start ntfsmac automatically on login") {
                 Toggle("", isOn: $settings.launchAtLogin).labelsHidden()
             }
@@ -48,9 +86,9 @@ public struct PreferencesView: View {
                 }
             }
         }
-        .padding(16)
-        .frame(width: 360)
-        .windowGlassBackground()
+        .padding(12)
+        .frame(width: 320)
+        .fixedSize(horizontal: false, vertical: true)
         .confirmationDialog(
             "Uninstall ntfsmac completely?",
             isPresented: $isConfirmingUninstall

--- a/gui/Preferences/PreferencesView.swift
+++ b/gui/Preferences/PreferencesView.swift
@@ -1,5 +1,26 @@
 import SwiftUI
 
+/// MenuBarExtra uses a transient window. A native `confirmationDialog` dismisses that window as
+/// its destructive button is selected, which made the uninstall action appear to vanish before
+/// it reliably reached `HelperUninstaller`. Keep confirmation state in the popover itself instead.
+public struct UninstallConfirmationPresentation: Equatable, Sendable {
+    public private(set) var isVisible: Bool
+
+    public init(isVisible: Bool = false) {
+        self.isVisible = isVisible
+    }
+
+    public mutating func request() { isVisible = true }
+    public mutating func cancel() { isVisible = false }
+
+    /// Consumes one explicit confirmation. A stale/double action cannot start two uninstalls.
+    public mutating func confirm() -> Bool {
+        guard isVisible else { return false }
+        isVisible = false
+        return true
+    }
+}
+
 /// GUI-PLAN.md "Settings page" table, using the same controls and application-owned state as the
 /// former Preferences window. "Reinstall privileged helper" reuses `HelperInstaller.install()`
 /// directly — the same path `3-first-run-install` built for first-run, per that unit's Do clause.
@@ -10,7 +31,7 @@ public struct PreferencesView: View {
     public let onBack: (() -> Void)?
 
     @Environment(\.colorScheme) private var colorScheme
-    @State private var isConfirmingUninstall = false
+    @State private var uninstallConfirmation: UninstallConfirmationPresentation
 
     public init(
         settings: Settings,
@@ -18,10 +39,27 @@ public struct PreferencesView: View {
         uninstaller: HelperUninstaller,
         onBack: (() -> Void)?
     ) {
+        self.init(
+            settings: settings,
+            installer: installer,
+            uninstaller: uninstaller,
+            onBack: onBack,
+            uninstallConfirmation: .init()
+        )
+    }
+
+    init(
+        settings: Settings,
+        installer: HelperInstaller,
+        uninstaller: HelperUninstaller,
+        onBack: (() -> Void)?,
+        uninstallConfirmation: UninstallConfirmationPresentation
+    ) {
         self.settings = settings
         self.installer = installer
         self.uninstaller = uninstaller
         self.onBack = onBack
+        _uninstallConfirmation = State(initialValue: uninstallConfirmation)
     }
 
     /// Source-compatible initializer for existing embeddings. The production app always supplies
@@ -80,37 +118,70 @@ public struct PreferencesView: View {
                         ProgressView().controlSize(.small)
                     }
                     Button("Uninstall…", role: .destructive) {
-                        isConfirmingUninstall = true
+                        uninstallConfirmation.request()
                     }
-                    .disabled(uninstaller.state == .removingDependencies || uninstaller.state == .removingHelper)
+                    .disabled(
+                        uninstaller.state == .removingDependencies
+                            || uninstaller.state == .removingHelper
+                            || isUninstallComplete
+                    )
                 }
+            }
+
+            if uninstallConfirmation.isVisible {
+                inlineUninstallConfirmation
             }
         }
         .padding(12)
         .frame(width: 320)
         .fixedSize(horizontal: false, vertical: true)
-        .confirmationDialog(
-            "Uninstall ntfsmac completely?",
-            isPresented: $isConfirmingUninstall
-        ) {
-            Button("Uninstall Everything", role: .destructive) {
-                Task { await uninstaller.uninstallEverything() }
+    }
+
+    private var inlineUninstallConfirmation: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Uninstall ntfsmac completely?")
+                .font(.system(size: 13, weight: .semibold))
+            Text("Removes the CLI, all vendored dependencies, and this privileged helper. Afterward, you can drag ntfsmac.app to the Trash. This can't be undone.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel") {
+                    uninstallConfirmation.cancel()
+                }
+                .buttonStyle(.glassNeutral(colorScheme: colorScheme))
+
+                Button("Uninstall Everything", role: .destructive) {
+                    guard uninstallConfirmation.confirm() else { return }
+                    Task { await uninstaller.uninstallEverything() }
+                }
+                .buttonStyle(.glassDestructive(colorScheme: colorScheme))
             }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Removes the CLI, all vendored dependencies, and this privileged helper. After this, dragging ntfsmac.app to the Trash leaves nothing behind. This can't be undone — you'll need to reinstall to use ntfsmac again.")
         }
+        .glassCard()
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Confirm complete ntfsmac uninstall")
     }
 
     private var uninstallSubtitle: String {
         switch uninstaller.state {
-        case .idle, .removingDependencies, .removingHelper:
+        case .idle:
             return "Remove the CLI, dependencies, and this helper — no leftovers"
+        case .removingDependencies:
+            return "Removing CLI and dependencies…"
+        case .removingHelper:
+            return "Removing privileged helper…"
         case .done:
             return "Uninstalled. Safe to drag ntfsmac.app to the Trash."
         case .failed(let message):
             return "Failed: \(message)"
         }
+    }
+
+    private var isUninstallComplete: Bool {
+        if case .done = uninstaller.state { return true }
+        return false
     }
 
     @ViewBuilder

--- a/gui/Preferences/ProductVersion.swift
+++ b/gui/Preferences/ProductVersion.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Product/build version shown in Settings. The packaged app reads this from its own Info.plist;
+/// keeping the formatting in a value type makes missing/malformed bundle metadata testable.
+public struct ProductVersion: Equatable, Sendable {
+    public let release: String
+    public let build: String
+
+    public init(release: String, build: String) {
+        self.release = release
+        self.build = build
+    }
+
+    public static func current(bundle: Bundle = .main) -> Self {
+        resolve(infoDictionary: bundle.infoDictionary ?? [:])
+    }
+
+    public static func resolve(infoDictionary: [String: Any]) -> Self {
+        let release = normalized(infoDictionary["CFBundleShortVersionString"]) ?? "Unknown"
+        let build = normalized(infoDictionary["CFBundleVersion"]) ?? "Unknown"
+        return .init(release: release, build: build)
+    }
+
+    public var settingsText: String {
+        guard build != "Unknown", build != release else { return "Version \(release)" }
+        return "Version \(release) (\(build))"
+    }
+
+    private static func normalized(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/gui/Preferences/Settings.swift
+++ b/gui/Preferences/Settings.swift
@@ -21,7 +21,7 @@ public struct RealLaunchAtLoginService: LaunchAtLoginService {
     }
 }
 
-/// GUI-PLAN.md "Preferences window" table, exactly these five controls — this unit's Don't
+/// GUI-PLAN.md "Settings page" table, exactly these controls — this unit's Don't
 /// clause: no controls beyond this table. Persisted via `UserDefaults` (constructor-injected so
 /// tests use an isolated suite, never the real `.standard` domain).
 @MainActor
@@ -49,7 +49,7 @@ public final class Settings: ObservableObject {
         launchAtLogin = defaults.object(forKey: Keys.launchAtLogin) as? Bool ?? Defaults.launchAtLogin
     }
 
-    /// GUI-PLAN.md "Preferences window" table's literal Default column.
+    /// GUI-PLAN.md "Settings page" table's literal Default column.
     public enum Defaults {
         public static let launchAtLogin = false
     }

--- a/gui/State/PopoverNavigation.swift
+++ b/gui/State/PopoverNavigation.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Navigation local to the menu-bar popover. Keeping this state in the popover's view graph lets
+/// every entry point (normal content, first run, and CLI repair) open the same Settings page while
+/// retaining the app-owned Settings/helper objects that are already in flight.
+@MainActor
+public final class PopoverNavigation: ObservableObject {
+    public enum Page: Equatable, Sendable {
+        case main
+        case settings
+    }
+
+    @Published public private(set) var page: Page = .main
+
+    public init() {}
+
+    public func showSettings() {
+        page = .settings
+    }
+
+    public func showMain() {
+        page = .main
+    }
+}

--- a/gui/Style/GlassTheme.swift
+++ b/gui/Style/GlassTheme.swift
@@ -61,11 +61,8 @@ struct PopoverGlassBackground: ViewModifier {
     }
 }
 
-/// Preferences window content background — the comp's "Prefs content" recipe
-/// (`rgba(18,18,24,0.72)` over a blurred base, dark only shown). The window titlebar (traffic
-/// lights, its own blur) is real native `NSWindow` chrome in the actual app — the comp fakes it
-/// in static HTML because it's a mockup; nothing to translate there, faking it here would
-/// duplicate what AppKit already draws for free.
+/// Retained for public source compatibility with earlier embeddings. The production Settings
+/// page no longer uses this window-only treatment because it lives inside the popover.
 struct WindowGlassBackground: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
 
@@ -81,7 +78,7 @@ struct WindowGlassBackground: ViewModifier {
     }
 }
 
-/// Preferences row card — `ui/prototype.html`'s "Row:" comps: `rgba(255,255,255,0.05)` fill,
+/// Settings row card — `ui/prototype.html`'s "Row:" comps: `rgba(255,255,255,0.05)` fill,
 /// `rgba(255,255,255,0.08)` border, 10pt radius (dark only shown in the comp; light follows the
 /// same white-alpha→black-alpha substitution the mounted-state dark/light pair already
 /// establishes throughout the rest of the comp, not a new invented value).
@@ -106,8 +103,9 @@ struct GlassCard: ViewModifier {
 public extension View {
     /// Menu-bar popover container glass — apply once at the popover content root.
     func popoverGlassBackground() -> some View { modifier(PopoverGlassBackground()) }
-    /// Preferences window content glass — apply once at the window's root view.
+    /// Compatibility-only window treatment; ntfsmac itself no longer opens a Settings window.
+    @available(*, deprecated, message: "Settings is now presented inside the popover")
     func windowGlassBackground() -> some View { modifier(WindowGlassBackground()) }
-    /// One Preferences row's card chrome.
+    /// One Settings row's card chrome.
     func glassCard() -> some View { modifier(GlassCard()) }
 }

--- a/gui/Tests/HelperClientTests.swift
+++ b/gui/Tests/HelperClientTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import NtfsmacGUI
+
+private final class ConnectionFactoryProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCallCount = 0
+
+    var callCount: Int {
+        lock.withLock { storedCallCount }
+    }
+
+    func makeConnection(machServiceName: String) -> NSXPCConnection {
+        lock.withLock { storedCallCount += 1 }
+        return NSXPCConnection(machServiceName: machServiceName, options: .privileged)
+    }
+}
+
+@MainActor
+@Test func helperClientDoesNotConnectBeforeTheFirstPrivilegedRequest() {
+    let probe = ConnectionFactoryProbe()
+    let client = HelperClient(
+        machServiceName: "com.khr898.ntfsmac.tests.lazy-helper",
+        connectionFactory: probe.makeConnection(machServiceName:)
+    )
+
+    #expect(probe.callCount == 0, "constructing the app before first-run install must not bootstrap XPC")
+    withExtendedLifetime(client) {}
+    #expect(probe.callCount == 0)
+}

--- a/gui/Tests/PopoverNavigationTests.swift
+++ b/gui/Tests/PopoverNavigationTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import NtfsmacGUI
+
+@MainActor
+@Test func popoverNavigationStartsOnMainAndSupportsRoundTrip() {
+    let navigation = PopoverNavigation()
+
+    #expect(navigation.page == .main)
+
+    navigation.showSettings()
+    #expect(navigation.page == .settings)
+
+    navigation.showMain()
+    #expect(navigation.page == .main)
+}
+
+@MainActor
+@Test func repeatedNavigationRequestsAreIdempotent() {
+    let navigation = PopoverNavigation()
+
+    navigation.showSettings()
+    navigation.showSettings()
+    #expect(navigation.page == .settings)
+
+    navigation.showMain()
+    navigation.showMain()
+    #expect(navigation.page == .main)
+}

--- a/gui/Tests/PopoverStateRenderTests.swift
+++ b/gui/Tests/PopoverStateRenderTests.swift
@@ -55,7 +55,8 @@ private func renderPopover(
     mountController: MountController,
     helperInstaller: HelperInstaller,
     cliInstallChecker: CLIInstallChecker,
-    driveScanner: DriveScanner = DriveScanner()
+    driveScanner: DriveScanner = DriveScanner(),
+    navigation: PopoverNavigation = PopoverNavigation()
 ) -> CGSize? {
     let view = PopoverContentView(
         appState: appState,
@@ -65,15 +66,77 @@ private func renderPopover(
         remountController: RemountController(appState: appState),
         diagnoseRunner: DiagnoseRunner(),
         helperInstaller: helperInstaller,
+        helperUninstaller: HelperUninstaller(),
         cliInstallChecker: cliInstallChecker,
         cliAutoStager: CLIAutoStager(checker: cliInstallChecker),
         settings: Settings(defaults: UserDefaults(suiteName: UUID().uuidString)!),
         finderOpener: FinderOpener(),
-        helperClient: HelperClient()
+        helperClient: HelperClient(),
+        navigation: navigation
     )
     let renderer = ImageRenderer(content: view)
     guard let image = renderer.nsImage, image.size.width > 0, image.size.height > 0 else { return nil }
     return image.size
+}
+
+@MainActor @Test func settingsPageRendersFromNormalContentWithoutASeparateWindow() async throws {
+    let (helperInstaller, cliInstallChecker, cleanup) = try await makeInstalledDependencies()
+    defer { cleanup() }
+    let navigation = PopoverNavigation()
+    navigation.showSettings()
+    let appState = AppState()
+
+    let size = renderPopover(
+        appState: appState,
+        mountController: MountController(helper: FakeHelper(), appState: appState),
+        helperInstaller: helperInstaller,
+        cliInstallChecker: cliInstallChecker,
+        navigation: navigation
+    )
+
+    #expect(size?.width == 320)
+    #expect(navigation.page == .settings)
+}
+
+@MainActor @Test func settingsRouteIsAvailableDuringFirstRun() {
+    let navigation = PopoverNavigation()
+    navigation.showSettings()
+    let checker = CLIInstallChecker(candidatePaths: ["/nonexistent"], anylinuxfsPaths: ["/nonexistent"])
+    checker.check()
+    let appState = AppState()
+
+    let size = renderPopover(
+        appState: appState,
+        mountController: MountController(helper: FakeHelper(), appState: appState),
+        helperInstaller: HelperInstaller(service: InstalledService()),
+        cliInstallChecker: checker,
+        navigation: navigation
+    )
+
+    #expect(size?.width == 320)
+}
+
+@MainActor @Test func settingsRouteIsAvailableDuringCliRepair() async {
+    let helperInstaller = HelperInstaller(service: InstalledService())
+    await helperInstaller.installIfNeeded()
+    #expect(helperInstaller.state == .installed)
+
+    let checker = CLIInstallChecker(candidatePaths: ["/nonexistent"], anylinuxfsPaths: ["/nonexistent"])
+    checker.check()
+    #expect(!checker.isInstalled)
+
+    let navigation = PopoverNavigation()
+    navigation.showSettings()
+    let appState = AppState()
+    let size = renderPopover(
+        appState: appState,
+        mountController: MountController(helper: FakeHelper(), appState: appState),
+        helperInstaller: helperInstaller,
+        cliInstallChecker: checker,
+        navigation: navigation
+    )
+
+    #expect(size?.width == 320)
 }
 
 @MainActor @Test func mountedReadWriteStateRendersWithoutCollapsing() async throws {

--- a/gui/Tests/PreferencesUninstallTests.swift
+++ b/gui/Tests/PreferencesUninstallTests.swift
@@ -29,6 +29,7 @@ import Testing
         installer: HelperInstaller(),
         uninstaller: HelperUninstaller(),
         onBack: {},
+        productVersion: ProductVersion(release: "test", build: "test"),
         uninstallConfirmation: .init(isVisible: true)
     )
     let renderer = ImageRenderer(content: view)

--- a/gui/Tests/PreferencesUninstallTests.swift
+++ b/gui/Tests/PreferencesUninstallTests.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import Testing
+@testable import NtfsmacGUI
+
+@Test func inlineUninstallConfirmationRequiresOneVisibleExplicitConfirmation() {
+    var presentation = UninstallConfirmationPresentation()
+    #expect(!presentation.isVisible)
+    let confirmationWhileHidden = presentation.confirm()
+    #expect(!confirmationWhileHidden)
+
+    presentation.request()
+    #expect(presentation.isVisible)
+    presentation.cancel()
+    #expect(!presentation.isVisible)
+
+    presentation.request()
+    let firstConfirmation = presentation.confirm()
+    #expect(firstConfirmation)
+    #expect(!presentation.isVisible)
+    let duplicateConfirmation = presentation.confirm()
+    #expect(!duplicateConfirmation, "one click must never start two destructive flows")
+}
+
+@MainActor
+@Test func inlineUninstallConfirmationRendersInsideTheSettingsPopover() {
+    let defaults = UserDefaults(suiteName: "com.khr898.ntfsmac.tests.uninstall.\(UUID().uuidString)")!
+    let view = PreferencesView(
+        settings: Settings(defaults: defaults),
+        installer: HelperInstaller(),
+        uninstaller: HelperUninstaller(),
+        onBack: {},
+        uninstallConfirmation: .init(isVisible: true)
+    )
+    let renderer = ImageRenderer(content: view)
+
+    #expect(renderer.nsImage?.size.width == 320)
+    #expect((renderer.nsImage?.size.height ?? 0) > 200)
+}

--- a/gui/Tests/ProductVersionTests.swift
+++ b/gui/Tests/ProductVersionTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import NtfsmacGUI
+
+@Test func productVersionFormatsReleaseAndBuildForSettings() {
+    let version = ProductVersion.resolve(infoDictionary: [
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "1",
+    ])
+
+    #expect(version == ProductVersion(release: "1.0", build: "1"))
+    #expect(version.settingsText == "Version 1.0 (1)")
+}
+
+@Test func productVersionHandlesMissingOrRedundantBuildMetadata() {
+    #expect(ProductVersion.resolve(infoDictionary: [:]).settingsText == "Version Unknown")
+    #expect(
+        ProductVersion(release: "1.0", build: "1.0").settingsText == "Version 1.0"
+    )
+}

--- a/gui/Tests/SettingsTests.swift
+++ b/gui/Tests/SettingsTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import NtfsmacGUI
 
-// GUI-PLAN.md "Preferences window". Acceptance: assert defaults + persistence round-trip.
+// GUI-PLAN.md "Settings page". Acceptance: assert defaults + persistence round-trip.
 // Uses an isolated UserDefaults suite per test (never the real .standard domain).
 
 private func makeIsolatedDefaults(_ testName: String) -> UserDefaults {

--- a/gui/Views/CLIMissingView.swift
+++ b/gui/Views/CLIMissingView.swift
@@ -15,12 +15,23 @@ public struct CLIMissingView: View {
     @Environment(\.colorScheme) private var colorScheme
     @ObservedObject public var checker: CLIInstallChecker
     @ObservedObject public var stager: CLIAutoStager
+    public let onOpenSettings: () -> Void
     public let onQuit: () -> Void
 
-    public init(checker: CLIInstallChecker, stager: CLIAutoStager, onQuit: @escaping () -> Void) {
+    public init(
+        checker: CLIInstallChecker,
+        stager: CLIAutoStager,
+        onOpenSettings: @escaping () -> Void,
+        onQuit: @escaping () -> Void
+    ) {
         self.checker = checker
         self.stager = stager
+        self.onOpenSettings = onOpenSettings
         self.onQuit = onQuit
+    }
+
+    public init(checker: CLIInstallChecker, stager: CLIAutoStager, onQuit: @escaping () -> Void) {
+        self.init(checker: checker, stager: stager, onOpenSettings: {}, onQuit: onQuit)
     }
 
     public var body: some View {
@@ -73,7 +84,7 @@ public struct CLIMissingView: View {
 
             HStack(spacing: 5) {
                 Button {
-                    PreferencesOpener.open()
+                    onOpenSettings()
                 } label: {
                     SettingsGearGlyph(color: colorScheme == .dark ? .white.opacity(0.52) : .black.opacity(0.45))
                 }

--- a/gui/Views/FirstRunView.swift
+++ b/gui/Views/FirstRunView.swift
@@ -13,15 +13,26 @@ import AppKit
 public struct FirstRunView: View {
     @ObservedObject public var installer: HelperInstaller
     @ObservedObject public var diagnoseRunner: DiagnoseRunner
+    public let onOpenSettings: () -> Void
     public let onQuit: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var showDiagnose = false
 
-    public init(installer: HelperInstaller, diagnoseRunner: DiagnoseRunner, onQuit: @escaping () -> Void) {
+    public init(
+        installer: HelperInstaller,
+        diagnoseRunner: DiagnoseRunner,
+        onOpenSettings: @escaping () -> Void,
+        onQuit: @escaping () -> Void
+    ) {
         self.installer = installer
         self.diagnoseRunner = diagnoseRunner
+        self.onOpenSettings = onOpenSettings
         self.onQuit = onQuit
+    }
+
+    public init(installer: HelperInstaller, diagnoseRunner: DiagnoseRunner, onQuit: @escaping () -> Void) {
+        self.init(installer: installer, diagnoseRunner: diagnoseRunner, onOpenSettings: {}, onQuit: onQuit)
     }
 
     public var body: some View {
@@ -133,7 +144,7 @@ public struct FirstRunView: View {
     private var footer: some View {
         HStack {
             Button {
-                PreferencesOpener.open()
+                onOpenSettings()
             } label: {
                 SettingsGearGlyph(color: .secondary)
             }

--- a/gui/Views/PopoverContentView.swift
+++ b/gui/Views/PopoverContentView.swift
@@ -63,9 +63,11 @@ public struct PopoverContentView: View {
     @ObservedObject public var remountController: RemountController
     @ObservedObject public var diagnoseRunner: DiagnoseRunner
     @ObservedObject public var helperInstaller: HelperInstaller
+    @ObservedObject public var helperUninstaller: HelperUninstaller
     @ObservedObject public var cliInstallChecker: CLIInstallChecker
     @ObservedObject public var cliAutoStager: CLIAutoStager
     @ObservedObject public var settings: Settings
+    @StateObject private var navigation: PopoverNavigation
     public let finderOpener: FinderOpener
     public let helperClient: HelperClient
 
@@ -81,11 +83,13 @@ public struct PopoverContentView: View {
         remountController: RemountController,
         diagnoseRunner: DiagnoseRunner,
         helperInstaller: HelperInstaller,
+        helperUninstaller: HelperUninstaller,
         cliInstallChecker: CLIInstallChecker,
         cliAutoStager: CLIAutoStager,
         settings: Settings,
         finderOpener: FinderOpener,
-        helperClient: HelperClient
+        helperClient: HelperClient,
+        navigation: PopoverNavigation
     ) {
         self.appState = appState
         self.driveScanner = driveScanner
@@ -94,23 +98,59 @@ public struct PopoverContentView: View {
         self.remountController = remountController
         self.diagnoseRunner = diagnoseRunner
         self.helperInstaller = helperInstaller
+        self.helperUninstaller = helperUninstaller
         self.cliInstallChecker = cliInstallChecker
         self.cliAutoStager = cliAutoStager
         self.settings = settings
         self.finderOpener = finderOpener
         self.helperClient = helperClient
+        _navigation = StateObject(wrappedValue: navigation)
+    }
+
+    /// Source-compatible initializer matching the original public surface. The production app
+    /// supplies its long-lived uninstaller/navigation objects through the designated initializer.
+    public init(
+        appState: AppState,
+        driveScanner: DriveScanner,
+        mountController: MountController,
+        throughputMonitor: ThroughputMonitor,
+        remountController: RemountController,
+        diagnoseRunner: DiagnoseRunner,
+        helperInstaller: HelperInstaller,
+        cliInstallChecker: CLIInstallChecker,
+        cliAutoStager: CLIAutoStager,
+        settings: Settings,
+        finderOpener: FinderOpener,
+        helperClient: HelperClient
+    ) {
+        self.init(
+            appState: appState,
+            driveScanner: driveScanner,
+            mountController: mountController,
+            throughputMonitor: throughputMonitor,
+            remountController: remountController,
+            diagnoseRunner: diagnoseRunner,
+            helperInstaller: helperInstaller,
+            helperUninstaller: HelperUninstaller(),
+            cliInstallChecker: cliInstallChecker,
+            cliAutoStager: cliAutoStager,
+            settings: settings,
+            finderOpener: finderOpener,
+            helperClient: helperClient,
+            navigation: PopoverNavigation()
+        )
     }
 
     public var body: some View {
         Group {
-            // Helper install is a self-contained SMJobBless/XPC flow that doesn't touch the CLI
-            // tree at all — gating it behind `cliInstallChecker.isInstalled` would block the
-            // "Install Helper…" button while the CLI is still being staged. `CLIAutoStager`
-            // stages the CLI (bundled into the .app by `build/package-app.sh`, no tap/Homebrew
-            // needed) the moment the helper finishes installing, so helper state is checked
-            // first; CLI-missing is the brief, self-clearing window between "helper just
-            // installed" and "CLIAutoStager finished running install.sh through it."
-            if showFDAPrompt {
+            if navigation.page == .settings {
+                PreferencesView(
+                    settings: settings,
+                    installer: helperInstaller,
+                    uninstaller: helperUninstaller,
+                    onBack: navigation.showMain
+                )
+            } else if showFDAPrompt {
                 FDAPromptView(
                     onOpenSettings: {
                         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") {
@@ -124,12 +164,27 @@ public struct PopoverContentView: View {
                         mountController.clearError()
                     }
                 )
+            // Helper install is a self-contained SMJobBless/XPC flow that doesn't touch the CLI
+            // tree at all — gating it behind `cliInstallChecker.isInstalled` would block the
+            // "Install Helper…" button while the CLI is still being staged. `CLIAutoStager`
+            // stages the CLI (bundled into the .app by `build/package-app.sh`, no tap/Homebrew
+            // needed) the moment the helper finishes installing, so helper state is checked
+            // first; CLI-missing is the brief, self-clearing window between "helper just
+            // installed" and "CLIAutoStager finished running install.sh through it."
             } else if helperInstaller.state != .installed {
-                // GUI-PLAN.md "App shape": "No windows except Preferences and the first-run
-                // helper prompt" — the popover itself gates on the helper being installed first.
-                FirstRunView(installer: helperInstaller, diagnoseRunner: diagnoseRunner, onQuit: quit)
+                FirstRunView(
+                    installer: helperInstaller,
+                    diagnoseRunner: diagnoseRunner,
+                    onOpenSettings: navigation.showSettings,
+                    onQuit: quit
+                )
             } else if !cliInstallChecker.isInstalled {
-                CLIMissingView(checker: cliInstallChecker, stager: cliAutoStager, onQuit: quit)
+                CLIMissingView(
+                    checker: cliInstallChecker,
+                    stager: cliAutoStager,
+                    onOpenSettings: navigation.showSettings,
+                    onQuit: quit
+                )
             } else {
                 mainContent
             }
@@ -138,6 +193,9 @@ public struct PopoverContentView: View {
             if newValue == "FDA_REQUIRED" {
                 showFDAPrompt = true
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .ntfsmacOpenSettings)) { _ in
+            navigation.showSettings()
         }
     }
 
@@ -346,7 +404,7 @@ public struct PopoverContentView: View {
     private var footer: some View {
         HStack(spacing: 5) {
             Button {
-                PreferencesOpener.open()
+                navigation.showSettings()
             } label: {
                 SettingsGearGlyph(color: .secondary)
             }
@@ -445,4 +503,3 @@ struct FDAPromptView: View {
         .frame(width: 340)
     }
 }
-


### PR DESCRIPTION
## Summary

Keep Settings and its destructive uninstall flow inside the existing menu-bar popover.

## Implementation

- replace the separate Preferences window with one shared in-popover Settings route and an accessible Back action
- show the app release/build from bundle metadata as secondary text below the Settings title
- render uninstall confirmation inline so the transient popover cannot close before the helper request starts
- consume confirmation once, disable duplicate/in-progress/completed uninstall actions, and report progress in place
- create the helper XPC connection lazily on the first privileged request instead of at app launch
- keep the same app-owned Settings, installer, and uninstaller objects across normal, first-run, and CLI-repair routes

## Compatibility

- no XPC protocol, mount, unmount, filesystem, signing, or deployment-target change
- macOS 13 remains the minimum
- existing public initializers remain source-compatible

## Validation

- `swift test`: 170 tests passed
- `swift package diagnose-api-breaking-changes upstream/main --targets NtfsmacGUI`: no breaking changes
- packaging suite: 7 tests passed, including bundle assembly and ad-hoc signing
- live packaged-app validation: Settings stayed inside the popover, bundle version rendered correctly, Back restored the drive list
- live fresh-install validation: the privileged helper uninstalled on the first confirmed attempt; the UI reached `Uninstalled`, and launchd/helper/runtime residues were absent

Documentation and the manual test checklist are updated with the final behavior.
