### PR TITLE
fix: detect MBR Windows_NTFS volumes

### DIFF
--- a/cli/lib/list-drives.sh
+++ b/cli/lib/list-drives.sh
@@ -13,12 +13,11 @@ set -u
 
 # Filesystems ntfsmac mounts: NTFS + BitLocker + ext2/3/4 (kernel auto-detect, no --fs-driver).
 # The real anylinuxfs TYPE column is NOT always a single blkid fstype token: for NTFS, blkid's
-# fs_type is empty in this build, so darwin::augment_line falls back to the raw GPT type name
-# "Microsoft Basic Data" (vendor/.../diskutil/darwin.rs: fs_type.unwrap_or(part_type)). The
-# parser captures the whole TYPE+NAME blob and derives fstype from it — the "Microsoft Basic
-# Data" prefix is exactly what the server's own --microsoft filter keys on (WINDOWS_FS_TYPES
-# in vendor/.../diskutil/mod.rs), so matching it client-side replicates --microsoft's
-# reliability without a second anylinuxfs call. Note: "Microsoft Basic Data" is the GPT type
+# fs_type can be empty, so darwin::augment_line falls back to the raw partition type name:
+# "Microsoft Basic Data" on GPT and "Windows_NTFS" on MBR. The parser captures the whole
+# TYPE+NAME blob and derives fstype from it — both prefixes are in the server's own
+# WINDOWS_FS_TYPES set, so matching them client-side replicates --microsoft's reliability
+# without a second anylinuxfs call. Note: "Microsoft Basic Data" is the GPT type
 # for ntfs AND exfat; when blkid resolves exfat it surfaces as "exfat" and is dropped by the
 # allow-set, but the rare GPT-fallback case can't distinguish the two (same limitation as the
 # server's --microsoft filter). Keep this array and DriveListParser's allowedFsTypes in sync
@@ -73,7 +72,8 @@ list_mountable_drives() {
       local blob="${BASH_REMATCH[1]}" size="${BASH_REMATCH[2]}" ident="${BASH_REMATCH[3]}"
       [[ "$ident" =~ ^disk[0-9]+s[0-9]+$ ]] || continue
       # Derive fstype + label from the TYPE+NAME blob. The GPT type name "Microsoft Basic
-      # Data" covers ntfs AND exfat (both use that GPT type). exfat is out of scope — when
+      # Data" covers ntfs AND exfat (both use that GPT type), while "Windows_NTFS" is emitted
+      # for MBR NTFS partitions. exfat is out of scope — when
       # blkid resolves it, it surfaces as "exfat" and is dropped by NTFSMAC_ALLOWED_FS_TYPES;
       # the rare GPT-fallback case can't distinguish ntfs from exfat (same limitation as the
       # server's --microsoft filter). Match it as a prefix — same key the server filter uses,
@@ -83,6 +83,9 @@ list_mountable_drives() {
       if [[ "$blob" == "Microsoft Basic Data"* ]]; then
         fstype="ntfs"
         label="${blob#Microsoft Basic Data}"
+      elif [[ "$blob" == "Windows_NTFS"* ]]; then
+        fstype="ntfs"
+        label="${blob#Windows_NTFS}"
       elif [[ "$blob" == "BitLocker"* ]]; then
         fstype="BitLocker"
         label="${blob#BitLocker}"

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -118,12 +118,12 @@ $NTFSMAC_PREFIX/bin/anylinuxfs list             # should list your drive as ntfs
                                                  # folded in here)
 ```
 
-Verified, no fix needed: `anylinuxfs list --microsoft` (what the GUI's `DriveScanner` also calls)
-already lists every "Windows Basic Data" partition — `diskutil` names GPT Windows partitions
-`Microsoft Basic Data` and legacy MBR ones `Windows_NTFS`/`Windows_FAT_32`; vendor's own
-`WINDOWS_PART_TYPES` filter (`vendor/src/anylinuxfs/anylinuxfs/src/diskutil/mod.rs:288-293`)
-already matches all three, restricted to `ntfs`/`exfat`/`BitLocker` filesystems
-(`WINDOWS_FS_TYPES`). Nothing to change here.
+Fixed: `anylinuxfs list` can preserve the raw partition type when blkid does not return an NTFS
+fstype. GPT partitions then appear as `Microsoft Basic Data`, while real MBR NTFS media appears
+as `Windows_NTFS`. The GUI and CLI parsers already normalized the GPT prefix but treated the MBR
+prefix as an unknown fstype and silently dropped the drive. Both parsers now normalize
+`Windows_NTFS` to `ntfs` and preserve any following volume label. Regression fixtures mirror two
+real external MBR disks: an unlabeled 248 GB `disk4s1` and labeled 8.1 GB `USB_8GB`/`disk5s1`.
 
 Fixed — confirmed a real code bug, not a Parallels/nested-virtualization environment issue as
 first suspected (ruled out: confirmed this exact run was on the bare Apple Silicon Mac Terminal).
@@ -267,8 +267,8 @@ The menu-bar icon itself uses a placeholder SF Symbol for now — see "app icon"
    `NTFSMAC_PREFIX=/usr/local/ntfsmac ./install.sh` (real `sudo`-writable location, may need
    `sudo` for `/usr/local`) once, or tell me and I'll check what `HelperClient`/`HelperService`
    actually expect before you do anything destructive to `/usr/local`.
-2. Popover should show your drive in the list (same `anylinuxfs list --microsoft` data Part A's
-   `list` command showed). Click `[Mount]`.
+2. Popover should show your drive in the list (the same filtered `anylinuxfs list` data Part A's
+   `list` command showed, including MBR `Windows_NTFS`). Click `[Mount]`.
 3. Icon should pulse blue while mounting, then turn green with the drive shown as mounted, a
    live (if idle) speed bar, and security indicators.
 4. Click `Open in Finder` — a real Finder window should reveal the mount point.

--- a/docs/dev/TESTING.md
+++ b/docs/dev/TESTING.md
@@ -269,6 +269,9 @@ The menu-bar icon itself uses a placeholder SF Symbol for now — see "app icon"
    actually expect before you do anything destructive to `/usr/local`.
 2. Popover should show your drive in the list (the same filtered `anylinuxfs list` data Part A's
    `list` command showed, including MBR `Windows_NTFS`). Click `[Mount]`.
+   If Full Disk Access is required, macOS lists the component as
+   `com.khr898.ntfsmac.helper`; this is the technical service name of **ntfsmac Helper**, not an
+   unrelated package. Enable that exact entry, return to ntfsmac, and retry the mount.
 3. Icon should pulse blue while mounting, then turn green with the drive shown as mounted, a
    live (if idle) speed bar, and security indicators.
 4. Click `Open in Finder` — a real Finder window should reveal the mount point.

--- a/gui/Drives/DriveScanner.swift
+++ b/gui/Drives/DriveScanner.swift
@@ -34,13 +34,13 @@ public struct Drive: Identifiable, Equatable, Sendable {
 /// scheme line) and the header line never end in a `diskNsM` identifier, so anchoring on
 /// `validateDevice` for the trailing token naturally excludes them without special-casing.
 ///
-/// The TYPE column is NOT always a single blkid fstype token: for NTFS, blkid's fs_type is
-/// empty in this build, so `augment_line` falls back to the raw GPT type name "Microsoft Basic
-/// Data" (darwin.rs: `fs_type.unwrap_or(part_type)`). The regex captures the TYPE+NAME columns
-/// as one blob and `deriveFsTypeAndLabel` splits fstype from its prefix — "Microsoft Basic Data"
-/// is exactly what the server's `--microsoft` filter keys on (WINDOWS_FS_TYPES in mod.rs), so
-/// matching it client-side replicates `--microsoft`'s reliability without a second `anylinuxfs`
-/// call. The fstype is display-only — mount validates `--fs-driver` itself, never the picker.
+/// The TYPE column is NOT always a single blkid fstype token: for NTFS, blkid's fs_type can be
+/// empty, so `augment_line` falls back to the raw partition type. GPT then reports "Microsoft
+/// Basic Data", while MBR reports "Windows_NTFS". The regex captures the TYPE+NAME columns as
+/// one blob and `deriveFsTypeAndLabel` maps both prefixes to ntfs. Both names are part of the
+/// server's WINDOWS_FS_TYPES set, so matching them client-side replicates `--microsoft`'s
+/// reliability without a second `anylinuxfs` call. The fstype is display-only — mount validates
+/// `--fs-driver` itself, never the picker.
 ///
 /// Scope filter: bare `anylinuxfs list` returns every Linux FS type (btrfs/xfs/zfs/LUKS/LVM/...).
 /// ntfsmac mounts only NTFS + BitLocker + ext2/3/4 (exFAT is excluded — macOS already reads/writes
@@ -82,14 +82,18 @@ public enum DriveListParser {
     /// Splits the TYPE+NAME blob into (fstype, label). "Microsoft Basic Data" is the GPT type
     /// for ntfs (and exfat, but exfat is out of scope — when blkid resolves exfat it surfaces as
     /// "exfat" and is dropped by `allowedFsTypes`; the rare GPT-fallback case can't distinguish
-    /// ntfs from exfat, same limitation as the server's `--microsoft` filter). Match it as a
-    /// prefix, same key the server filter uses, so NTFS survives even when blkid's fs_type is
-    /// empty. "BitLocker" is its own GPT type. Everything else is a blkid single-token fstype
-    /// (ext2/3/4, sometimes ntfs) followed by the label.
+    /// ntfs from exfat, same limitation as the server's `--microsoft` filter). "Windows_NTFS"
+    /// is the corresponding MBR type emitted by real external disks. Match both as prefixes so
+    /// NTFS survives even when blkid's fs_type is empty. "BitLocker" is its own partition type.
+    /// Everything else is a blkid single-token fstype (ext2/3/4, sometimes ntfs) plus the label.
     private static func deriveFsTypeAndLabel(_ blob: String) -> (fsType: String, label: String) {
         let trimmed = blob.trimmingCharacters(in: .whitespaces)
         if trimmed.hasPrefix("Microsoft Basic Data") {
             let label = trimmed.dropFirst("Microsoft Basic Data".count).trimmingCharacters(in: .whitespaces)
+            return ("ntfs", label)
+        }
+        if trimmed.hasPrefix("Windows_NTFS") {
+            let label = trimmed.dropFirst("Windows_NTFS".count).trimmingCharacters(in: .whitespaces)
             return ("ntfs", label)
         }
         if trimmed.hasPrefix("BitLocker") {

--- a/gui/Tests/DriveScannerTests.swift
+++ b/gui/Tests/DriveScannerTests.swift
@@ -118,6 +118,33 @@ private let sampleExtOutput = """
     #expect(drives[0].identifier == "disk4s4")
 }
 
+@Test func parsesUnlabeledNtfsWithRealMbrWindowsNtfsTypeColumn() {
+    // Captured from a real 248 GB external MBR disk. With no blkid fstype/volume label,
+    // anylinuxfs preserves diskutil's "Windows_NTFS" partition type. Treating the first token
+    // as an allow-listed fstype used to drop this row entirely from the GUI.
+    let realMbrNtfsOutput = """
+    /dev/disk4 (external, physical):
+       #:                       TYPE NAME                    SIZE       IDENTIFIER
+       0:     FDisk_partition_scheme                        *248.0 GB   disk4
+       1:               Windows_NTFS                         248.0 GB   disk4s1
+    """
+    let drives = DriveListParser.parse(realMbrNtfsOutput)
+    #expect(drives == [Drive(identifier: "disk4s1", fsType: "ntfs", label: "", size: "248.0 GB")])
+}
+
+@Test func parsesLabeledNtfsWithRealMbrWindowsNtfsTypeColumn() {
+    // Captured from a second real MBR USB stick. Text after the partition-type prefix is the
+    // volume label and must remain visible to the picker.
+    let realMbrNtfsOutput = """
+    /dev/disk5 (external, physical):
+       #:                       TYPE NAME                    SIZE       IDENTIFIER
+       0:     FDisk_partition_scheme                        *8.1 GB     disk5
+       1:               Windows_NTFS USB_8GB                 8.1 GB     disk5s1
+    """
+    let drives = DriveListParser.parse(realMbrNtfsOutput)
+    #expect(drives == [Drive(identifier: "disk5s1", fsType: "ntfs", label: "USB_8GB", size: "8.1 GB")])
+}
+
 @Test func parsesExtWithRealLinuxFilesystemTypeColumn() {
     // Real anylinuxfs list output for ext when blkid can't resolve the superblock: blkid fs_type
     // is empty, so darwin::augment_line falls back to the raw GPT type name "Linux Filesystem" for

--- a/gui/Tests/FDAPromptCopyTests.swift
+++ b/gui/Tests/FDAPromptCopyTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import NtfsmacGUI
+
+@Suite struct FDAPromptCopyTests {
+    @Test func explainsTheTechnicalServiceNameInFriendlyTerms() {
+        #expect(FDAPromptCopy.instructions.contains("ntfsmac Helper"))
+        #expect(FDAPromptCopy.instructions.contains(FDAPromptCopy.helperServiceName))
+        #expect(FDAPromptCopy.instructions.contains("technical service name"))
+    }
+}

--- a/gui/Views/PopoverContentView.swift
+++ b/gui/Views/PopoverContentView.swift
@@ -392,7 +392,12 @@ public struct PopoverContentView: View {
     }
 }
 
-/// A beautiful modal prompt guiding the user to grant Full Disk Access to the privileged helper daemon.
+enum FDAPromptCopy {
+    static let helperServiceName = "com.khr898.ntfsmac.helper"
+    static let instructions = "macOS lists the ntfsmac Helper under its technical service name, \(helperServiceName). Enable that entry in Full Disk Access. If it is not listed, add it with the '+' button."
+}
+
+/// A modal prompt guiding the user to grant Full Disk Access to the privileged helper daemon.
 struct FDAPromptView: View {
     let onOpenSettings: () -> Void
     let onCancel: () -> Void
@@ -421,7 +426,7 @@ struct FDAPromptView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             
-            Text("To proceed, open System Settings and ensure the **ntfsmac helper** (com.khr898.ntfsmac.helper) is enabled under the Full Disk Access list. If it is not in the list, you can add it manually using the '+' button.")
+            Text(FDAPromptCopy.instructions)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.leading)

--- a/tests/cli/list-drives.bats
+++ b/tests/cli/list-drives.bats
@@ -69,6 +69,33 @@ STUB
   [[ "$output" == *"disk4s4"* ]]
 }
 
+@test "list_mountable_drives surfaces unlabeled MBR NTFS with real Windows_NTFS TYPE column" {
+  # Captured from a real 248 GB external MBR disk. Windows_NTFS is the partition type, not an
+  # allow-listed blkid token; it must be normalized to ntfs rather than dropped.
+  cat > "$STUB_DIR/anylinuxfs" <<STUB
+#!/bin/bash
+printf '%s\n' '   1:               Windows_NTFS                         248.0 GB   disk4s1'
+exit 0
+STUB
+  chmod +x "$STUB_DIR/anylinuxfs"
+  run list_mountable_drives
+  [ "$status" -eq 0 ]
+  [ "$output" = $'disk4s1\t\t248.0 GB\tntfs' ]
+}
+
+@test "list_mountable_drives preserves label from real MBR Windows_NTFS TYPE column" {
+  # Captured from a second real 8.1 GB USB stick.
+  cat > "$STUB_DIR/anylinuxfs" <<STUB
+#!/bin/bash
+printf '%s\n' '   1:               Windows_NTFS USB_8GB                 8.1 GB     disk5s1'
+exit 0
+STUB
+  chmod +x "$STUB_DIR/anylinuxfs"
+  run list_mountable_drives
+  [ "$status" -eq 0 ]
+  [ "$output" = $'disk5s1\tUSB_8GB\t8.1 GB\tntfs' ]
+}
+
 @test "list_mountable_drives calls anylinuxfs list without --microsoft" {
   CALL_LOG="$STUB_DIR/list.calls"
   cat > "$STUB_DIR/anylinuxfs" <<STUB


### PR DESCRIPTION
## Summary

Fix discovery of MBR-formatted NTFS media reported by `diskutil` as `Windows_NTFS`.

Both the Swift GUI parser and shell CLI parser now normalize that filesystem prefix to `ntfs` while preserving an optional volume label. Existing GPT `Microsoft Basic Data` detection remains unchanged.

The Full Disk Access guidance also uses the friendly name **ntfsmac Helper** and explains that macOS may display its unchanged technical service name. The helper identifier, launchd label, filename, XPC contract, and privilege boundary are not renamed.

## Scope

- drive discovery and user-facing guidance only
- no mount-driver, NFS, signing, entitlement, deployment-target, or privileged-operation change
- no raw `sudo` path added

## Validation

- `swift test`: 163 tests passed
- full Bash suite: 187 tests passed
- targeted drive-listing suite: 11 tests passed
- SwiftPM API check: no breaking changes
- packaged app signature and DMG integrity checks passed
- real MBR NTFS media, with and without a label, appeared in the GUI
- mount, write, read-back, cleanup, and GUI unmount completed successfully with no residual NFS mount
