### PR TITLE
fix(gui): restore diagnostics and Settings wiring lost during PR integration

### DIFF
--- a/gui/Preferences/PreferencesView.swift
+++ b/gui/Preferences/PreferencesView.swift
@@ -96,8 +96,14 @@ public struct PreferencesView: View {
                 // Spacers would center it in the *remaining* space after the Back button, sitting
                 // right-of-true-center. The title is the visual anchor; Back is overlaid leading.
                 ZStack {
-                    Text("Settings")
-                        .font(.system(size: 13, weight: .semibold))
+                    VStack(spacing: 1) {
+                        Text("Settings")
+                            .font(.system(size: 13, weight: .semibold))
+                        Text(productVersion.settingsText)
+                            .font(.system(size: 9, weight: .regular))
+                            .foregroundStyle(.secondary.opacity(0.72))
+                            .accessibilityLabel("ntfsmac \(productVersion.settingsText)")
+                    }
                     HStack {
                         Button {
                             onBack()
@@ -170,9 +176,8 @@ public struct PreferencesView: View {
         }
         .padding(16)
         .frame(width: 320)
+        .fixedSize(horizontal: false, vertical: true)
         .onAppear { settings.refreshLaunchAtLoginStatus() }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Confirm complete ntfsmac uninstall")
     }
 
     private var uninstallSubtitle: String {
@@ -220,6 +225,9 @@ public struct PreferencesView: View {
                 .buttonStyle(.glassDestructive(colorScheme: colorScheme))
             }
         }
+        .glassCard()
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Confirm complete ntfsmac uninstall")
     }
 
     private var isUninstallComplete: Bool {

--- a/gui/Tests/DeveloperDiagnoseExportTests.swift
+++ b/gui/Tests/DeveloperDiagnoseExportTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import NtfsmacGUI
 
 private let developerJSON = """
-{"healthy":false,"macos_version":"26.5","missing_binaries":0,"quarantined_binaries":0,"kernel_pin":"match","bridge":"down"}
+{"diagnostic_schema":2,"healthy":false,"ntfsmac_version":"1.0","build_version":"1","macos_version":"26.5","architecture":"arm64","helper_installed":true,"missing_binaries":1,"missing_components":["vmproxy"],"quarantined_binaries":0,"quarantined_components":[],"kernel_pin":"match","bridge":"down","vpn_default_route":true,"nfs_mount_count":2}
 """
 
 @Test func commandModifierSelectsDeveloperExportWithoutChangingNormalClick() {
@@ -16,12 +16,27 @@ private let developerJSON = """
     #expect(document.data.last == 0x0A)
 
     let object = try JSONSerialization.jsonObject(with: document.data) as? [String: Any]
+    #expect(object?["diagnostic_schema"] as? Int == 2)
     #expect(object?["healthy"] as? Bool == false)
+    #expect(object?["ntfsmac_version"] as? String == "1.0")
+    #expect(object?["build_version"] as? String == "1")
     #expect(object?["macos_version"] as? String == "26.5")
-    #expect(object?["missing_binaries"] as? Int == 0)
+    #expect(object?["architecture"] as? String == "arm64")
+    #expect(object?["helper_installed"] as? Bool == true)
+    #expect(object?["missing_binaries"] as? Int == 1)
+    #expect(object?["missing_components"] as? [String] == ["vmproxy"])
     #expect(object?["quarantined_binaries"] as? Int == 0)
+    #expect(object?["quarantined_components"] as? [String] == [])
     #expect(object?["kernel_pin"] as? String == "match")
     #expect(object?["bridge"] as? String == "down")
+    #expect(object?["vpn_default_route"] as? Bool == true)
+    #expect(object?["nfs_mount_count"] as? Int == 2)
+
+    let forbiddenKeys = [
+        "username", "serial", "hardware_model", "volume_labels", "device_identifiers",
+        "mount_paths", "vpn_provider", "vpn_interface", "ip_addresses", "dns_servers", "routes",
+    ]
+    #expect(forbiddenKeys.allSatisfy { object?[$0] == nil })
 }
 
 @Test func malformedDeveloperOutputIsRejected() {

--- a/gui/Tests/DiagnoseRunnerTests.swift
+++ b/gui/Tests/DiagnoseRunnerTests.swift
@@ -15,8 +15,12 @@ private let degradedJSON = """
 {"healthy":false,"missing_binaries":2,"quarantined_binaries":1,"kernel_pin":"mismatch","bridge":"down"}
 """
 
+private let expandedJSON = """
+{"diagnostic_schema":2,"healthy":true,"ntfsmac_version":"1.0","build_version":"1","macos_version":"26.6","architecture":"arm64","helper_installed":true,"missing_binaries":0,"missing_components":[],"quarantined_binaries":0,"quarantined_components":[],"kernel_pin":"match","bridge":"up","vpn_default_route":true,"nfs_mount_count":1}
+"""
+
 private let developerExportJSON = """
-{"healthy":false,"macos_version":"26.5","missing_binaries":0,"quarantined_binaries":0,"kernel_pin":"match","bridge":"down"}
+{"diagnostic_schema":2,"healthy":false,"ntfsmac_version":"1.0","build_version":"1","macos_version":"26.5","architecture":"arm64","helper_installed":true,"missing_binaries":1,"missing_components":["vmproxy"],"quarantined_binaries":0,"quarantined_components":[],"kernel_pin":"match","bridge":"down","vpn_default_route":false,"nfs_mount_count":0}
 """
 
 private final class FakeRunner: PrivilegedCommandRunning {
@@ -53,6 +57,51 @@ private final class FakeRunner: PrivilegedCommandRunning {
     #expect(rows.first(where: { $0.id == "quarantine" })?.value == "1 quarantined")
     #expect(rows.first(where: { $0.id == "kernel" })?.status == .warning)
     #expect(rows.first(where: { $0.id == "bridge" })?.status == .unavailable)
+}
+
+@Test func expandedReportProducesPrivacySafeDeveloperRows() throws {
+    let report = try JSONDecoder().decode(DiagnoseReport.self, from: Data(expandedJSON.utf8))
+    let rows = DiagnoseSummary.rows(for: report)
+
+    #expect(report.diagnosticSchema == 2)
+    #expect(rows.map(\.id) == [
+        "version", "system", "binaries", "quarantine", "kernel", "bridge", "helper", "vpn", "mounts",
+    ])
+    #expect(rows.first(where: { $0.id == "version" })?.value == "1.0 (1)")
+    #expect(rows.first(where: { $0.id == "system" })?.value == "macOS 26.6 · arm64")
+    #expect(rows.first(where: { $0.id == "helper" })?.value == "Installed")
+    #expect(rows.first(where: { $0.id == "vpn" })?.value == "Default route uses a tunnel")
+    #expect(rows.first(where: { $0.id == "mounts" })?.value == "1 active")
+}
+
+@Test func expandedReportNamesOnlyFixedFailingComponents() throws {
+    let report = try JSONDecoder().decode(DiagnoseReport.self, from: Data(developerExportJSON.utf8))
+    let rows = DiagnoseSummary.rows(for: report)
+
+    #expect(rows.first(where: { $0.id == "binaries" })?.value == "Missing: vmproxy")
+    #expect(rows.first(where: { $0.id == "quarantine" })?.value == "Clear")
+}
+
+@Test func expandedSystemRowWarnsForUnsupportedHost() {
+    let report = DiagnoseReport(
+        healthy: false,
+        missingBinaries: 0,
+        quarantinedBinaries: 0,
+        kernelPin: "match",
+        bridge: "down",
+        diagnosticSchema: 2,
+        ntfsmacVersion: "1.0",
+        buildVersion: "1",
+        macosVersion: "12.6",
+        architecture: "arm64",
+        helperInstalled: true,
+        missingComponents: [],
+        quarantinedComponents: [],
+        vpnDefaultRoute: false,
+        nfsMountCount: 0
+    )
+
+    #expect(DiagnoseSummary.rows(for: report).first(where: { $0.id == "system" })?.status == .warning)
 }
 
 @Test(arguments: ["match", "mismatch", "missing", "unknown", "malformed"])
@@ -127,7 +176,10 @@ func bridgeDownUsesMountContext(argument: (MountState, DiagnoseStatus, String)) 
     #expect(runner.errorMessage == nil)
     #expect(document != nil)
     let object = try JSONSerialization.jsonObject(with: document!.data) as? [String: Any]
+    #expect(object?["diagnostic_schema"] as? Int == 2)
+    #expect(object?["ntfsmac_version"] as? String == "1.0")
     #expect(object?["macos_version"] as? String == "26.5")
+    #expect(object?["missing_components"] as? [String] == ["vmproxy"])
 }
 
 @MainActor

--- a/gui/Tests/FDAPromptCopyTests.swift
+++ b/gui/Tests/FDAPromptCopyTests.swift
@@ -6,5 +6,7 @@ import Testing
         #expect(FDAPromptCopy.instructions.contains("ntfsmac Helper"))
         #expect(FDAPromptCopy.instructions.contains(FDAPromptCopy.helperServiceName))
         #expect(FDAPromptCopy.instructions.contains("technical service name"))
+        #expect(FDAPromptCopy.instructions.contains("generic executable icon"))
+        #expect(FDAPromptCopy.instructions.contains("standalone privileged tool"))
     }
 }

--- a/gui/Views/DiagnosePanel.swift
+++ b/gui/Views/DiagnosePanel.swift
@@ -60,37 +60,118 @@ public enum DiagnoseSummary {
     }
 
     public static func rows(for report: DiagnoseReport, mountState: MountState?) -> [DiagnoseSummaryRow] {
-        [
-            binariesRow(missingCount: report.missingBinaries),
-            quarantineRow(quarantinedCount: report.quarantinedBinaries),
+        var rows: [DiagnoseSummaryRow] = []
+        if let version = versionRow(release: report.ntfsmacVersion, build: report.buildVersion) {
+            rows.append(version)
+        }
+        if let system = systemRow(
+            macOSVersion: report.macosVersion,
+            architecture: report.architecture
+        ) {
+            rows.append(system)
+        }
+        rows.append(contentsOf: [
+            binariesRow(
+                missingCount: report.missingBinaries,
+                components: report.missingComponents
+            ),
+            quarantineRow(
+                quarantinedCount: report.quarantinedBinaries,
+                components: report.quarantinedComponents
+            ),
             kernelRow(rawValue: report.kernelPin),
             bridgeRow(rawValue: report.bridge, mountState: mountState),
-        ]
+        ])
+        if let helperInstalled = report.helperInstalled {
+            rows.append(helperRow(installed: helperInstalled))
+        }
+        if let vpnDefaultRoute = report.vpnDefaultRoute {
+            rows.append(vpnRow(detected: vpnDefaultRoute))
+        }
+        if let mountCount = report.nfsMountCount {
+            rows.append(mountCountRow(count: mountCount))
+        }
+        return rows
     }
 
-    private static func binariesRow(missingCount: Int) -> DiagnoseSummaryRow {
+    private static func versionRow(release: String?, build: String?) -> DiagnoseSummaryRow? {
+        guard let release, !release.isEmpty else { return nil }
+        let value = build.map {
+            $0.isEmpty || $0 == release ? release : "\(release) (\($0))"
+        } ?? release
+        return .init(
+            id: "version",
+            label: "ntfsmac",
+            value: value,
+            status: release == "unknown" ? .unavailable : .informational,
+            explanation: "The product and build versions that produced this diagnostic report."
+        )
+    }
+
+    private static func systemRow(
+        macOSVersion: String?,
+        architecture: String?
+    ) -> DiagnoseSummaryRow? {
+        guard macOSVersion != nil || architecture != nil else { return nil }
+        let os = macOSVersion ?? "unknown"
+        let arch = architecture ?? "unknown architecture"
+        let macOSMajor = macOSVersion.flatMap { Int($0.split(separator: ".").first ?? "") }
+        let status: DiagnoseStatus
+        if let architecture, architecture != "arm64" {
+            status = .warning
+        } else if let macOSMajor, macOSMajor < 13 {
+            status = .warning
+        } else if architecture == "arm64", let macOSMajor, macOSMajor >= 13 {
+            status = .healthy
+        } else {
+            status = .unavailable
+        }
+        return .init(
+            id: "system",
+            label: "System",
+            value: "macOS \(os) · \(arch)",
+            status: status,
+            explanation: "ntfsmac requires Apple Silicon and macOS 13.0 or newer."
+        )
+    }
+
+    private static func binariesRow(
+        missingCount: Int,
+        components: [String]?
+    ) -> DiagnoseSummaryRow {
         let explanation = "These are the four runtime components required by ntfsmac. Missing components require installation or repair."
         guard missingCount >= 0 else {
             return .init(id: "binaries", label: "Vendor binaries", value: "Unknown", status: .unavailable, explanation: explanation)
         }
+        let namedMissing = components?.filter { !$0.isEmpty } ?? []
+        let missingValue = namedMissing.isEmpty
+            ? "\(missingCount) missing"
+            : "Missing: \(namedMissing.joined(separator: ", "))"
         return .init(
             id: "binaries",
             label: "Vendor binaries",
-            value: missingCount == 0 ? "All present" : "\(missingCount) missing",
+            value: missingCount == 0 ? "All present" : missingValue,
             status: missingCount == 0 ? .healthy : .warning,
             explanation: explanation
         )
     }
 
-    private static func quarantineRow(quarantinedCount: Int) -> DiagnoseSummaryRow {
+    private static func quarantineRow(
+        quarantinedCount: Int,
+        components: [String]?
+    ) -> DiagnoseSummaryRow {
         let explanation = "macOS quarantine can prevent downloaded runtime components from executing."
         guard quarantinedCount >= 0 else {
             return .init(id: "quarantine", label: "Quarantine", value: "Unknown", status: .unavailable, explanation: explanation)
         }
+        let namedQuarantined = components?.filter { !$0.isEmpty } ?? []
+        let quarantinedValue = namedQuarantined.isEmpty
+            ? "\(quarantinedCount) quarantined"
+            : "Quarantined: \(namedQuarantined.joined(separator: ", "))"
         return .init(
             id: "quarantine",
             label: "Quarantine",
-            value: quarantinedCount == 0 ? "Clear" : "\(quarantinedCount) quarantined",
+            value: quarantinedCount == 0 ? "Clear" : quarantinedValue,
             status: quarantinedCount == 0 ? .healthy : .warning,
             explanation: explanation
         )
@@ -131,6 +212,46 @@ public enum DiagnoseSummary {
         case .error, .none:
             return .init(id: "bridge", label: "vmnet bridge", value: "Inactive — mount context unavailable", status: .unavailable, explanation: explanation)
         }
+    }
+
+    private static func helperRow(installed: Bool) -> DiagnoseSummaryRow {
+        .init(
+            id: "helper",
+            label: "Privileged helper",
+            value: installed ? "Installed" : "Not installed",
+            status: installed ? .healthy : .informational,
+            explanation: "The GUI uses its SMJobBless helper for mount, unmount, firewall, and route operations. A CLI-only installation may not need it."
+        )
+    }
+
+    private static func vpnRow(detected: Bool) -> DiagnoseSummaryRow {
+        .init(
+            id: "vpn",
+            label: "VPN routing",
+            value: detected ? "Default route uses a tunnel" : "No tunnel default route detected",
+            status: .informational,
+            explanation: "Only a yes/no tunnel signal is reported; ntfsmac never includes the VPN provider, interface name, addresses, DNS, or routes."
+        )
+    }
+
+    private static func mountCountRow(count: Int) -> DiagnoseSummaryRow {
+        let explanation = "Number of active NFS mounts, without device names, labels, or paths."
+        guard count >= 0 else {
+            return .init(
+                id: "mounts",
+                label: "NFS mounts",
+                value: "Unknown",
+                status: .unavailable,
+                explanation: explanation
+            )
+        }
+        return .init(
+            id: "mounts",
+            label: "NFS mounts",
+            value: count == 0 ? "None" : "\(count) active",
+            status: count == 0 ? .informational : .healthy,
+            explanation: explanation
+        )
     }
 }
 

--- a/gui/Views/FirstRunView.swift
+++ b/gui/Views/FirstRunView.swift
@@ -63,8 +63,20 @@ public struct FirstRunView: View {
                 .buttonStyle(.glassPrimary())
 
                 Button {
+                    let mode = DiagnoseActionMode.resolve(
+                        commandPressed: NSEvent.modifierFlags.contains(.command)
+                    )
                     diagnosePresentation.show()
-                    Task { await diagnoseRunner.run() }
+                    Task {
+                        switch mode {
+                        case .summary:
+                            await diagnoseRunner.run()
+                        case .developerJSONExport:
+                            if let document = await diagnoseRunner.runForDeveloperExport() {
+                                DeveloperDiagnoseSavePanel.present(document: document)
+                            }
+                        }
+                    }
                 } label: {
                     HStack(spacing: 5) {
                         DiagnoseGlyph()

--- a/gui/Views/PopoverContentView.swift
+++ b/gui/Views/PopoverContentView.swift
@@ -301,7 +301,9 @@ public struct PopoverContentView: View {
             }
 
             if diagnosePresentation.isVisible {
-                DiagnosePanel(runner: diagnoseRunner, mountState: appState.state)
+                DiagnosePanel(runner: diagnoseRunner, mountState: appState.state) {
+                    diagnosePresentation.hide()
+                }
             }
 
             Divider()
@@ -416,8 +418,20 @@ public struct PopoverContentView: View {
             .help(TooltipCopy.text(for: .settings))
 
             Button {
+                let mode = DiagnoseActionMode.resolve(
+                    commandPressed: NSEvent.modifierFlags.contains(.command)
+                )
                 diagnosePresentation.show()
-                Task { await diagnoseRunner.run() }
+                Task {
+                    switch mode {
+                    case .summary:
+                        await diagnoseRunner.run()
+                    case .developerJSONExport:
+                        if let document = await diagnoseRunner.runForDeveloperExport() {
+                            DeveloperDiagnoseSavePanel.present(document: document)
+                        }
+                    }
+                }
             } label: {
                 HStack(spacing: 5) {
                     DiagnoseGlyph()

--- a/gui/Views/PopoverContentView.swift
+++ b/gui/Views/PopoverContentView.swift
@@ -479,7 +479,7 @@ public struct PopoverContentView: View {
 
 enum FDAPromptCopy {
     static let helperServiceName = "com.khr898.ntfsmac.helper"
-    static let instructions = "macOS lists the ntfsmac Helper under its technical service name, \(helperServiceName). Enable that entry in Full Disk Access. If it is not listed, add it with the '+' button."
+    static let instructions = "macOS lists ntfsmac Helper under its technical service name, \(helperServiceName), and may show a generic executable icon because the helper is a standalone privileged tool. Enable that exact entry in Full Disk Access. If it is not listed, add it with the '+' button."
 }
 
 /// A modal prompt guiding the user to grant Full Disk Access to the privileged helper daemon.


### PR DESCRIPTION
## Summary

Restores several user-facing GUI connections and presentation details that were unintentionally lost while resolving conflicts in the previous PR stack.

The underlying diagnostic, export, and version infrastructure was still present in the repository, but some production call sites and UI wiring were no longer connected. This allowed the project to build successfully while exposing an incomplete feature set.

This PR is based directly on the current upstream `main` and preserves all subsequent upstream v2 fixes.

## Changes

- Restore the **Hide** action in the main Diagnose panel.
- Restore Command-click Diagnose for exporting the privacy-safe developer JSON report.
- Make the same developer export available from the first-run/error flow.
- Restore the complete GUI diagnostic summary:
  - ntfsmac version and build
  - macOS version and architecture
  - required runtime binaries
  - quarantine state
  - kernel pin
  - vmnet bridge
  - privileged helper
  - VPN tunnel presence
  - active NFS mount count
- Restore the dynamically derived app version below the Settings heading.
- Restore the uninstall confirmation card styling and correctly scope its accessibility label.
- Clarify that macOS may display a generic executable icon for the standalone privileged helper in Full Disk Access.

## Privacy

The diagnostic summary and JSON export remain privacy-safe.

They do not include usernames, serial numbers, hardware identifiers, volume labels, device identifiers, mount paths, VPN providers, interface names, IP addresses, DNS servers, or routing tables.

## Scope

- Based directly on the current upstream `main`.
- No BinaryBears branding, roadmap, screenshots, or fork-specific documentation.
- No runtime pinning, SECURITY roadmap, or other P0 work.
- No old whole-file snapshots were restored.
- Later upstream multi-drive, helper lifecycle, Quit, and Settings layout fixes remain intact.
- The existing CLI diagnostic JSON schema is preserved.

## Validation

- `swift test`: 207 tests passed
- `bats tests/cli/diagnose.bats`: 16 tests passed
- `bash tests/run-all.sh`: 196 tests passed
- Full build, packaging, DMG, ad-hoc signing, CLI installation, and diagnostic gates passed
- Packaged application manually validated with the restored GUI flows